### PR TITLE
fix confusing typespecs and variable names in PullBuffer

### DIFF
--- a/lib/membrane/core/element/pad_controller.ex
+++ b/lib/membrane/core/element/pad_controller.ex
@@ -163,7 +163,7 @@ defmodule Membrane.Core.Element.PadController do
   defp init_pad_direction_data(%{direction: :source}, _props, _state), do: %{}
 
   defp init_pad_mode_data(%{mode: :pull, direction: :sink} = data, props, state) do
-    %{name: name, pid: pid, other_ref: other_ref, demand_in: demand_in} = data
+    %{pid: pid, other_ref: other_ref, demand_in: demand_in} = data
 
     :ok =
       pid
@@ -172,8 +172,8 @@ defmodule Membrane.Core.Element.PadController do
     pb =
       PullBuffer.new(
         state.name,
-        {pid, other_ref},
-        name,
+        pid,
+        other_ref,
         demand_in,
         props[:pull_buffer] || %{}
       )

--- a/spec/membrane/core/pull_buffer_spec.exs
+++ b/spec/membrane/core/pull_buffer_spec.exs
@@ -13,8 +13,7 @@ defmodule Membrane.Core.PullBufferSpec do
 
   describe ".new/5" do
     let :name, do: :name
-    let :sink, do: {self(), sink_elem_name()}
-    let :sink_elem_name, do: :sink_elem_name
+    let :demand_pid, do: self()
     let :sink_ref, do: :sink_pad_ref
     let :preferred_size, do: 100
     let :min_demand, do: 10
@@ -30,11 +29,11 @@ defmodule Membrane.Core.PullBufferSpec do
       ]
 
     it "should return PullBuffer struct and send demand message" do
-      expect(described_module().new(name(), sink(), sink_ref(), demand_in(), props()))
+      expect(described_module().new(name(), demand_pid(), sink_ref(), demand_in(), props()))
       |> to(
         eq(%PullBuffer{
           name: name(),
-          sink: sink(),
+          demand_pid: demand_pid(),
           sink_ref: sink_ref(),
           demand: 0,
           preferred_size: preferred_size(),
@@ -45,7 +44,7 @@ defmodule Membrane.Core.PullBufferSpec do
         })
       )
 
-      expected_list = [preferred_size(), sink_elem_name()]
+      expected_list = [preferred_size(), sink_ref()]
       assert_received {:membrane_demand, ^expected_list}
     end
 
@@ -55,11 +54,11 @@ defmodule Membrane.Core.PullBufferSpec do
       it "should not send the demand" do
         flush()
 
-        expect(described_module().new(name(), sink(), sink_ref(), demand_in(), props()))
+        expect(described_module().new(name(), demand_pid(), sink_ref(), demand_in(), props()))
         |> to(
           eq(%PullBuffer{
             name: name(),
-            sink: sink(),
+            demand_pid: demand_pid(),
             sink_ref: sink_ref(),
             demand: preferred_size(),
             preferred_size: preferred_size(),
@@ -173,7 +172,8 @@ defmodule Membrane.Core.PullBufferSpec do
         current_size: current_size(),
         demand: 0,
         min_demand: 0,
-        sink: {self(), sink_ref()},
+        demand_pid: self(),
+        sink_ref: sink_ref(),
         metric: metric(),
         q: q()
       }


### PR DESCRIPTION
I found some confusing variable names and typespecs in PullBuffer code