### PR TITLE
Fix error handling in handle_buffer_pull

### DIFF
--- a/lib/membrane/core/element/pad_model.ex
+++ b/lib/membrane/core/element/pad_model.ex
@@ -115,8 +115,7 @@ defmodule Membrane.Core.Element.PadModel do
     end
   end
 
-  @spec set_data!(Pad.ref_t(), keys :: atom | [atom], State.t()) ::
-          State.stateful_t(:ok | unknown_pad_error_t)
+  @spec set_data!(Pad.ref_t(), keys :: atom | [atom], State.t()) :: State.t()
   def set_data!(pad_ref, keys \\ [], v, state) do
     {:ok, state} = set_data(pad_ref, keys, v, state)
     state


### PR DESCRIPTION
If PullBuffer.store returned an error, handle_buffer_pull returned
error-reason tuple without state, so the error shown from pipeline was
not clear.