### PR TITLE
Allow to pass options to a pad while linking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
 elixir:
-  - 1.7
+  - 1.8
 otp_release:
   - 21.0
 sudo: false

--- a/lib/membrane/caps/matcher.ex
+++ b/lib/membrane/caps/matcher.ex
@@ -126,8 +126,7 @@ defmodule Membrane.Caps.Matcher do
 
   When `:any` is used as specs, caps can by anything (i.e. they can be invalid)
   """
-  @spec match?(:any, any()) :: true
-  @spec match?(caps_specs_t(), struct()) :: boolean()
+  @spec match?(caps_specs_t(), struct() | any()) :: boolean()
   def match?(:any, _), do: true
 
   def match?(specs, %_{} = caps) when is_list(specs) do

--- a/lib/membrane/core/element/buffer_controller.ex
+++ b/lib/membrane/core/element/buffer_controller.ex
@@ -3,7 +3,7 @@ defmodule Membrane.Core.Element.BufferController do
   # Module handling buffers incoming through input pads.
 
   alias Membrane.{Buffer, Core, Element}
-  alias Core.{CallbackHandler, PullBuffer}
+  alias Core.{CallbackHandler, InputBuffer}
   alias Element.{CallbackContext, Pad}
   alias Core.Element.{ActionHandler, DemandHandler, PadModel, State}
   require CallbackContext.{Process, Write}
@@ -12,7 +12,7 @@ defmodule Membrane.Core.Element.BufferController do
   use Bunch
 
   @doc """
-  Handles incoming buffer: either stores it in PullBuffer, or executes element's
+  Handles incoming buffer: either stores it in InputBuffer, or executes element's
   callback. Also calls `Membrane.Core.Element.DemandHandler.check_and_handle_demands/2`
   to check if there are any unsupplied demands.
   """
@@ -69,10 +69,10 @@ defmodule Membrane.Core.Element.BufferController do
     PadModel.assert_data!(pad_ref, %{direction: :input}, state)
 
     with {:ok, old_pb} <- PadModel.get_data(pad_ref, :buffer, state),
-         {:ok, pb} <- old_pb |> PullBuffer.store(buffers) do
+         {:ok, pb} <- old_pb |> InputBuffer.store(buffers) do
       state = PadModel.set_data!(pad_ref, :buffer, pb, state)
 
-      if old_pb |> PullBuffer.empty?() do
+      if old_pb |> InputBuffer.empty?() do
         DemandHandler.supply_demand(pad_ref, state)
       else
         {:ok, state}

--- a/lib/membrane/core/element/caps_controller.ex
+++ b/lib/membrane/core/element/caps_controller.ex
@@ -3,7 +3,7 @@ defmodule Membrane.Core.Element.CapsController do
   # Module handling caps received on input pads.
 
   alias Membrane.{Caps, Core, Element}
-  alias Core.{CallbackHandler, PullBuffer}
+  alias Core.{CallbackHandler, InputBuffer}
   alias Core.Element.{ActionHandler, PadModel, State}
   alias Element.{CallbackContext, Pad}
   require CallbackContext.Caps
@@ -12,18 +12,18 @@ defmodule Membrane.Core.Element.CapsController do
   use Bunch
 
   @doc """
-  Handles incoming caps: either stores them in PullBuffer, or executes element callback.
+  Handles incoming caps: either stores them in InputBuffer, or executes element callback.
   """
   @spec handle_caps(Pad.ref_t(), Caps.t(), State.t()) :: State.stateful_try_t()
   def handle_caps(pad_ref, caps, state) do
     PadModel.assert_data!(pad_ref, %{direction: :input}, state)
     data = PadModel.get_data!(pad_ref, state)
 
-    if data.mode == :pull and not (data.buffer |> PullBuffer.empty?()) do
+    if data.mode == :pull and not (data.buffer |> InputBuffer.empty?()) do
       PadModel.update_data(
         pad_ref,
         :buffer,
-        &(&1 |> PullBuffer.store(:caps, caps)),
+        &(&1 |> InputBuffer.store(:caps, caps)),
         state
       )
     else

--- a/lib/membrane/core/element/demand_handler.ex
+++ b/lib/membrane/core/element/demand_handler.ex
@@ -4,7 +4,7 @@ defmodule Membrane.Core.Element.DemandHandler do
 
   alias Membrane.Core
   alias Membrane.Element.Pad
-  alias Core.{Message, PullBuffer}
+  alias Core.{Message, InputBuffer}
 
   alias Core.Element.{
     BufferController,
@@ -56,7 +56,7 @@ defmodule Membrane.Core.Element.DemandHandler do
 
   This is necessary due to the case when one requests a demand action while previous
   demand is being supplied. This could lead to a situation where buffers are taken
-  from PullBuffer and passed to callbacks, while buffers being currently supplied
+  from InputBuffer and passed to callbacks, while buffers being currently supplied
   have not been processed yet, and therefore to changing order of buffers.
 
   Async mode is supported to handle the case when buffers are passed to
@@ -119,7 +119,7 @@ defmodule Membrane.Core.Element.DemandHandler do
   end
 
   @doc """
-  Based on the demand on the given pad takes PullBuffer contents
+  Based on the demand on the given pad takes InputBuffer contents
   and passes it to proper controllers.
   """
   @spec supply_demand(
@@ -137,7 +137,7 @@ defmodule Membrane.Core.Element.DemandHandler do
       PadModel.get_and_update_data(
         pad_ref,
         :buffer,
-        &(&1 |> PullBuffer.take(size)),
+        &(&1 |> InputBuffer.take(size)),
         state
       )
 

--- a/lib/membrane/core/element/event_controller.ex
+++ b/lib/membrane/core/element/event_controller.ex
@@ -3,7 +3,7 @@ defmodule Membrane.Core.Element.EventController do
   # Module handling events incoming through input pads.
 
   alias Membrane.{Core, Element, Event}
-  alias Core.{CallbackHandler, PullBuffer}
+  alias Core.{CallbackHandler, InputBuffer}
   alias Core.Element.{ActionHandler, PadModel, State}
   alias Element.{CallbackContext, Pad}
   require CallbackContext.Event
@@ -12,7 +12,7 @@ defmodule Membrane.Core.Element.EventController do
   use Bunch
 
   @doc """
-  Handles incoming event: either stores it in PullBuffer, or executes element callback.
+  Handles incoming event: either stores it in InputBuffer, or executes element callback.
   Extra checks and tasks required by special events such as `:start_of_stream`
   or `:end_of_stream` are performed.
   """
@@ -21,11 +21,11 @@ defmodule Membrane.Core.Element.EventController do
     pad_data = PadModel.get_data!(pad_ref, state)
 
     if not Event.async?(event) && pad_data.mode == :pull && pad_data.direction == :input &&
-         pad_data.buffer |> PullBuffer.empty?() |> Kernel.not() do
+         pad_data.buffer |> InputBuffer.empty?() |> Kernel.not() do
       PadModel.update_data(
         pad_ref,
         :buffer,
-        &(&1 |> PullBuffer.store(:event, event)),
+        &(&1 |> InputBuffer.store(:event, event)),
         state
       )
     else

--- a/lib/membrane/core/element/message_dispatcher.ex
+++ b/lib/membrane/core/element/message_dispatcher.ex
@@ -84,13 +84,11 @@ defmodule Membrane.Core.Element.MessageDispatcher do
   end
 
   defp do_handle_message(
-         Message.new(:handle_link, [pad_ref, pad_direction, pid, other_ref, props]),
+         Message.new(:handle_link, [pad_ref, pad_direction, pid, other_ref, other_info, props]),
          :call,
          state
        ) do
-    res = PadController.handle_link(pad_ref, pad_direction, pid, other_ref, props, state)
-    IO.inspect(res)
-    res
+    PadController.handle_link(pad_ref, pad_direction, pid, other_ref, other_info, props, state)
   end
 
   defp do_handle_message(Message.new(:handle_unlink, pad_ref), :call, state) do

--- a/lib/membrane/core/element/message_dispatcher.ex
+++ b/lib/membrane/core/element/message_dispatcher.ex
@@ -88,7 +88,9 @@ defmodule Membrane.Core.Element.MessageDispatcher do
          :call,
          state
        ) do
-    PadController.handle_link(pad_ref, pad_direction, pid, other_ref, props, state)
+    res = PadController.handle_link(pad_ref, pad_direction, pid, other_ref, props, state)
+    IO.inspect(res)
+    res
   end
 
   defp do_handle_message(Message.new(:handle_unlink, pad_ref), :call, state) do

--- a/lib/membrane/core/element/pad_controller.ex
+++ b/lib/membrane/core/element/pad_controller.ex
@@ -229,18 +229,19 @@ defmodule Membrane.Core.Element.PadController do
 
   @spec handle_pad_added(Pad.ref_t(), State.t()) :: State.stateful_try_t()
   defp handle_pad_added(ref, state) do
+    pad_opts = PadModel.get_data!(ref, :opts, state)
+
     context =
       CallbackContext.PadAdded.from_state(
         state,
-        direction: PadModel.get_data!(ref, :direction, state)
+        direction: PadModel.get_data!(ref, :direction, state),
+        opts: pad_opts
       )
-
-    pad_opts = PadModel.get_data!(ref, :opts, state)
 
     CallbackHandler.exec_and_handle_callback(
       :handle_pad_added,
       ActionHandler,
-      [ref, pad_opts, context],
+      [ref, context],
       state
     )
   end

--- a/lib/membrane/core/element/pad_controller.ex
+++ b/lib/membrane/core/element/pad_controller.ex
@@ -22,7 +22,7 @@ defmodule Membrane.Core.Element.PadController do
           Pad.direction_t(),
           pid,
           Pad.ref_t(),
-          Pad.Model.info_t(),
+          PadModel.pad_info_t(),
           Keyword.t(),
           State.t()
         ) ::
@@ -176,6 +176,12 @@ defmodule Membrane.Core.Element.PadController do
   defp init_pad_direction_data(%{direction: :input}, _props, _state), do: %{sticky_messages: []}
   defp init_pad_direction_data(%{direction: :output}, _props, _state), do: %{}
 
+  @spec init_pad_mode_data(
+          map(),
+          PadModel.pad_info_t(),
+          props :: Keyword.t(),
+          State.t()
+        ) :: map()
   defp init_pad_mode_data(%{mode: :pull, direction: :input} = data, other_info, props, state) do
     %{pid: pid, other_ref: other_ref, demand_unit: demand_unit} = data
 
@@ -183,11 +189,13 @@ defmodule Membrane.Core.Element.PadController do
       pid
       |> Message.call(:demand_unit, [demand_unit, other_ref])
 
-    buffer_props = (props[:buffer] || %{}) |> Map.new()
+    buffer_props = props[:buffer] || Keyword.new()
 
     buffer_props =
       if other_info.mode == :push do
-        buffer_props |> Map.put(:toilet, true)
+        buffer_props |> Keyword.put_new(:toilet, true)
+      else
+        buffer_props
       end
 
     pb =

--- a/lib/membrane/core/element/pad_controller.ex
+++ b/lib/membrane/core/element/pad_controller.ex
@@ -22,7 +22,7 @@ defmodule Membrane.Core.Element.PadController do
           Pad.direction_t(),
           pid,
           Pad.ref_t(),
-          PadModel.pad_info_t(),
+          PadModel.pad_info_t() | nil,
           Keyword.t(),
           State.t()
         ) ::
@@ -151,7 +151,7 @@ defmodule Membrane.Core.Element.PadController do
   end
 
   @spec validate_dir_and_mode(info :: PadModel.pad_info_t(), other_info :: PadModel.pad_info_t()) ::
-          boolean()
+          Type.try_t()
   def validate_dir_and_mode(%{direction: :output, mode: :pull}, %{direction: :input, mode: :push}) do
     {:error, {:cannot_connect, :pull_output, :to, :push_input}}
   end

--- a/lib/membrane/core/element/pad_controller.ex
+++ b/lib/membrane/core/element/pad_controller.ex
@@ -190,7 +190,7 @@ defmodule Membrane.Core.Element.PadController do
 
     data = data |> Map.merge(init_pad_direction_data(data, props, state))
     data = data |> Map.merge(init_pad_mode_data(data, other_info, props, state))
-    data = %Pad.Data{} |> Map.merge(data)
+    data = struct!(Pad.Data, data)
     state |> Bunch.Access.put_in([:pads, :data, ref], data)
   end
 

--- a/lib/membrane/core/element/pad_controller.ex
+++ b/lib/membrane/core/element/pad_controller.ex
@@ -152,6 +152,7 @@ defmodule Membrane.Core.Element.PadController do
       |> Map.merge(%{
         pid: pid,
         other_ref: other_ref,
+        opts: props[:pad],
         caps: nil,
         start_of_stream?: false,
         end_of_stream?: false
@@ -179,7 +180,7 @@ defmodule Membrane.Core.Element.PadController do
         pid,
         other_ref,
         demand_unit,
-        props[:pull_buffer] || %{}
+        props[:buffer] || %{}
       )
 
     %{buffer: pb, demand: 0}
@@ -217,10 +218,12 @@ defmodule Membrane.Core.Element.PadController do
         direction: PadModel.get_data!(ref, :direction, state)
       )
 
+    pad_opts = PadModel.get_data!(ref, :opts, state)
+
     CallbackHandler.exec_and_handle_callback(
       :handle_pad_added,
       ActionHandler,
-      [ref, context],
+      [ref, pad_opts, context],
       state
     )
   end

--- a/lib/membrane/core/element/pad_model.ex
+++ b/lib/membrane/core/element/pad_model.ex
@@ -192,7 +192,7 @@ defmodule Membrane.Core.Element.PadModel do
     {pad_data, state}
   end
 
-  @spec delete_data(Pad.ref_t(), State.t()) :: {:ok, State.t()} | {unknown_pad_error_t, State.t()}
+  @spec delete_data(Pad.ref_t(), State.t()) :: State.stateful_t(:ok | unknown_pad_error_t)
   def delete_data(pad_ref, state) do
     with {{:ok, _out}, state} <- pop_data(pad_ref, state) do
       {:ok, state}

--- a/lib/membrane/core/element/pad_model.ex
+++ b/lib/membrane/core/element/pad_model.ex
@@ -13,10 +13,8 @@ defmodule Membrane.Core.Element.PadModel do
           required(:availability) => Pad.availability_t(),
           required(:direction) => Pad.direction_t(),
           required(:mode) => Pad.mode_t(),
-          required(:options) => %{
-            optional(:demand_unit) => Membrane.Buffer.Metric.unit_t(),
-            optional(:other_demand_unit) => Membrane.Buffer.Metric.unit_t()
-          },
+          optional(:demand_unit) => Membrane.Buffer.Metric.unit_t(),
+          optional(:other_demand_unit) => Membrane.Buffer.Metric.unit_t(),
           optional(:current_id) => non_neg_integer
         }
 

--- a/lib/membrane/core/element/pad_model.ex
+++ b/lib/membrane/core/element/pad_model.ex
@@ -177,24 +177,26 @@ defmodule Membrane.Core.Element.PadModel do
   end
 
   @spec pop_data(Pad.ref_t(), State.t()) ::
-          State.stateful_t({:ok, Pad.Data.t() | any} | unknown_pad_error_t)
+          State.stateful_t({:ok, Pad.Data.t()} | unknown_pad_error_t)
   def pop_data(pad_ref, state) do
     with {:ok, state} <- {assert_instance(pad_ref, state), state} do
-      state
-      |> Bunch.Access.pop_in(data_keys(pad_ref))
-      ~> {:ok, &1}
+      {data, state} =
+        state
+        |> Bunch.Access.pop_in(data_keys(pad_ref))
+
+      {{:ok, data}, state}
     end
   end
 
-  @spec pop_data!(Pad.ref_t(), State.t()) :: State.stateful_t(Pad.Data.t() | any)
+  @spec pop_data!(Pad.ref_t(), State.t()) :: State.stateful_t(Pad.Data.t())
   def pop_data!(pad_ref, state) do
     {{:ok, pad_data}, state} = pop_data(pad_ref, state)
     {pad_data, state}
   end
 
-  @spec delete_data(Pad.ref_t(), State.t()) :: State.stateful_t(:ok | unknown_pad_error_t)
+  @spec delete_data(Pad.ref_t(), State.t()) :: {:ok, State.t()} | {unknown_pad_error_t, State.t()}
   def delete_data(pad_ref, state) do
-    with {:ok, {_out, state}} <- pop_data(pad_ref, state) do
+    with {{:ok, _out}, state} <- pop_data(pad_ref, state) do
       {:ok, state}
     end
   end

--- a/lib/membrane/core/element/pads_specs_parser.ex
+++ b/lib/membrane/core/element/pads_specs_parser.ex
@@ -58,7 +58,7 @@ defmodule Membrane.Core.Element.PadsSpecsParser do
           already_parsed :: [{Pad.name_t(), Pad.description_t()}],
           direction :: Pad.direction_t(),
           declaration_env :: Macro.Env.t()
-        ) :: Pad.description_t() | no_return
+        ) :: [{Pad.name_t(), Pad.description_t()}]
   def parse_pads_specs!(specs, already_parsed, direction, env) do
     with {:ok, specs} <- parse_pads_specs(specs, already_parsed, direction) do
       specs
@@ -78,7 +78,7 @@ defmodule Membrane.Core.Element.PadsSpecsParser do
           specs :: [Pad.spec_t()],
           already_parsed :: [{Pad.name_t(), Pad.description_t()}],
           direction :: Pad.direction_t()
-        ) :: Type.try_t(Pad.description_t())
+        ) :: Type.try_t([{Pad.name_t(), Pad.description_t()}])
   defp parse_pads_specs(specs, already_parsed, direction) do
     withl keyword: true <- specs |> Keyword.keyword?(),
           dups: [] <- (specs ++ already_parsed) |> Keyword.keys() |> Bunch.Enum.duplicates(),
@@ -91,6 +91,8 @@ defmodule Membrane.Core.Element.PadsSpecsParser do
     end
   end
 
+  @spec parse_pad_specs(Pad.spec_t(), Pad.direction_t()) ::
+          Type.try_t({Pad.name_t(), Pad.description_t()})
   defp parse_pad_specs(spec, direction) do
     withl spec: {name, config} when is_atom(name) and is_list(config) <- spec,
           config:

--- a/lib/membrane/core/pull_buffer.ex
+++ b/lib/membrane/core/pull_buffer.ex
@@ -46,6 +46,18 @@ defmodule Membrane.Core.PullBuffer do
 
   @typedoc """
   Properties that can be passed when creating new PullBuffer
+
+  Available options are:
+    * `:preffered_size` - size which will be the 'target' for PullBuffer - it will make demands
+      trying to grow to this size. Its default value depends on the set `#{inspect(Buffer.Metric)}` and is
+      obtained via `c:#{inspect(Buffer.Metric)}.pullbuffer_preferred_size/0`
+    * `:min_demand` - the minimal size of a demand that can be sent to the linked output pad.
+      This prevents from excessive message passing between elements. Defaults to a quarter of
+      preferred size.
+    * `warn_size` - in toilet mode (connecting push output to pull input pad), receiving more data
+      than this size triggers a warning. By default it is equal to twice the preffered size.
+    * `fail_size` - in toilet mode (connecting push output to pull input pad), receiving more data
+      than this results in an element failure. By default, it is four times the preffered size.
   """
   @type prop_t ::
           {:preferred_size, pos_integer()}

--- a/lib/membrane/core/pull_buffer.ex
+++ b/lib/membrane/core/pull_buffer.ex
@@ -47,6 +47,8 @@ defmodule Membrane.Core.PullBuffer do
           {:preferred_size, pos_integer()}
           | {:min_demand, pos_integer()}
           | {:toilet, boolean()}
+          | {:warn_size, pos_integer()}
+          | {:fail_size, pos_integer()}
 
   @type props_t :: [prop_t()]
 
@@ -61,13 +63,15 @@ defmodule Membrane.Core.PullBuffer do
     metric = Buffer.Metric.from_unit(demand_unit)
     preferred_size = props[:preferred_size] || metric.pullbuffer_preferred_size
     min_demand = props[:min_demand] || preferred_size |> div(4)
-    default_toilet = %{warn: preferred_size * 2, fail: preferred_size * 4}
 
     toilet =
-      case props[:toilet] do
-        true -> default_toilet
-        t when t in [nil, false] -> false
-        t -> default_toilet |> Map.merge(t |> Map.new())
+      if props[:toilet] do
+        %{
+          warn: props[:warn_size] || preferred_size * 2,
+          fail: props[:fail_size] || preferred_size * 4
+        }
+      else
+        false
       end
 
     %__MODULE__{

--- a/lib/membrane/core/pull_buffer.ex
+++ b/lib/membrane/core/pull_buffer.ex
@@ -18,8 +18,6 @@ defmodule Membrane.Core.PullBuffer do
 
   @non_buf_types [:event, :caps]
 
-  @typep toilet_t() :: boolean() | %{:warn => pos_integer, :fail => pos_integer}
-
   @type t :: %__MODULE__{
           name: Element.name_t(),
           demand_pid: pid(),
@@ -30,7 +28,7 @@ defmodule Membrane.Core.PullBuffer do
           demand: non_neg_integer(),
           min_demand: pos_integer(),
           metric: module(),
-          toilet: toilet_t()
+          toilet: %{:warn => pos_integer, :fail => pos_integer}
         }
 
   defstruct name: :pull_buffer,
@@ -65,7 +63,7 @@ defmodule Membrane.Core.PullBuffer do
           | {:warn_size, pos_integer()}
           | {:fail_size, pos_integer()}
 
-  @type props_t :: [prop_t()]
+  @type props_t :: [prop_t() | {:toilet, true}]
 
   @spec new(Element.name_t(), demand_pid :: pid, Pad.ref_t(), Buffer.Metric.unit_t(), props_t) ::
           t()

--- a/lib/membrane/core/pull_buffer.ex
+++ b/lib/membrane/core/pull_buffer.ex
@@ -50,7 +50,6 @@ defmodule Membrane.Core.PullBuffer do
   @type prop_t ::
           {:preferred_size, pos_integer()}
           | {:min_demand, pos_integer()}
-          | {:toilet, boolean()}
           | {:warn_size, pos_integer()}
           | {:fail_size, pos_integer()}
 

--- a/lib/membrane/core/pull_buffer.ex
+++ b/lib/membrane/core/pull_buffer.ex
@@ -128,28 +128,22 @@ defmodule Membrane.Core.PullBuffer do
         if size < fail_lvl do
           "warn level"
         else
-          "fail_level"
+          "fail level"
         end
 
       warn([
         """
-        PullBuffer #{inspect(pb.name)} (toilet): received #{inspect(size)} buffers,
+        PullBuffer #{inspect(pb.name)} (toilet) has buffers of size #{inspect(size)},
         which is above #{above_level}, from output #{inspect(pb.linked_output_ref)} that works in push mode.
-        To have control over amount of buffers being produced, consider using push mode.
-        If this is a normal situation, increase toilet warn/fail level.
-        Buffers: \
-        """,
-        Buffer.print(v),
-        """
-
-        PullBuffer #{inspect(pb)}
+        To have control over amount of buffers being produced, consider using pull mode.
+        If this is a normal situation, increase warn/fail size in buffer options.
         """
       ])
     end
 
     if size >= fail_lvl do
       warn_error(
-        "PullBuffer #{inspect(pb.name)} (toilet): failing: too many buffers",
+        "PullBuffer #{inspect(pb.name)} (toilet): failing: too much data",
         {:pull_buffer, toilet: :too_many_buffers}
       )
     else

--- a/lib/membrane/element.ex
+++ b/lib/membrane/element.ex
@@ -172,20 +172,22 @@ defmodule Membrane.Element do
 
   def link(%Link{from: %Endpoint{pid: from_pid} = from, to: %Endpoint{pid: to_pid} = to})
       when is_pid(from_pid) and is_pid(to_pid) do
-    with :ok <-
+    with {:ok, pad_from_info} <-
            Message.call(from_pid, :handle_link, [
              from.pad_ref,
              :output,
              to_pid,
              to.pad_ref,
+             nil,
              from.opts
            ]),
-         :ok <-
+         {:ok, _pad_to_info} <-
            Message.call(to_pid, :handle_link, [
              to.pad_ref,
              :input,
              from_pid,
              from.pad_ref,
+             pad_from_info,
              to.opts
            ]) do
       :ok

--- a/lib/membrane/element.ex
+++ b/lib/membrane/element.ex
@@ -8,8 +8,9 @@ defmodule Membrane.Element do
   doing so.
   """
 
-  alias __MODULE__.Pad
   alias Membrane.Core
+  alias Membrane.Pipeline.Link
+  alias Link.Endpoint
   alias Core.Element.{MessageDispatcher, State}
   alias Core.Message
   import Membrane.Helper.GenServer
@@ -164,25 +165,34 @@ defmodule Membrane.Element do
   @doc """
   Sends synchronous calls to two elements, telling them to link with each other.
   """
-  @spec link(
-          from_element :: pid,
-          to_element :: pid,
-          from_pad :: Pad.name_t(),
-          to_pad :: Pad.name_t(),
-          params :: list
-        ) :: :ok | {:error, any}
-  def link(pid, pid, _, _, _) when is_pid(pid) do
+  @spec link(link_spec :: %Link{}) :: :ok | {:error, any}
+  def link(%Link{from: %Endpoint{pid: pid}, to: %Endpoint{pid: pid}}) when is_pid(pid) do
     {:error, :loop}
   end
 
-  def link(from_pid, to_pid, from_pad, to_pad, params) when is_pid(from_pid) and is_pid(to_pid) do
-    with :ok <- Message.call(from_pid, :handle_link, [from_pad, :output, to_pid, to_pad, params]),
-         :ok <- Message.call(to_pid, :handle_link, [to_pad, :input, from_pid, from_pad, params]) do
+  def link(%Link{from: %Endpoint{pid: from_pid} = from, to: %Endpoint{pid: to_pid} = to})
+      when is_pid(from_pid) and is_pid(to_pid) do
+    with :ok <-
+           Message.call(from_pid, :handle_link, [
+             from.pad_ref,
+             :output,
+             to_pid,
+             to.pad_ref,
+             from.opts
+           ]),
+         :ok <-
+           Message.call(to_pid, :handle_link, [
+             to.pad_ref,
+             :input,
+             from_pid,
+             from.pad_ref,
+             to.opts
+           ]) do
       :ok
     end
   end
 
-  def link(_, _, _, _, _), do: {:error, :invalid_element}
+  def link(_), do: {:error, :invalid_element}
 
   @doc """
   Sends synchronous call to element, telling it to unlink all its pads.

--- a/lib/membrane/element/action.ex
+++ b/lib/membrane/element/action.ex
@@ -69,7 +69,7 @@ defmodule Membrane.Element.Action do
 
   The pad must have input direction and work in pull mode. This action does NOT
   entail _sending_ demand through the pad, but just _requesting_ some amount
-  of data from `Membrane.Core.PullBuffer`, which _sends_ demands automatically when it
+  of data from `Membrane.Core.InputBuffer`, which _sends_ demands automatically when it
   runs out of data.
   If there is any data available at the pad, the data is passed to
   `c:Membrane.Element.Base.Filter.handle_process_list/4`

--- a/lib/membrane/element/callback_context/caps.ex
+++ b/lib/membrane/element/callback_context/caps.ex
@@ -12,10 +12,10 @@ defmodule Membrane.Element.CallbackContext.Caps do
     old_caps: Membrane.Caps.t()
 
   @impl true
-  defmacro from_state(state, pad: pad) do
+  defmacro from_state(state, opts) do
     old_caps =
       quote do
-        unquote(pad) |> PadModel.get_data!(:caps, unquote(state))
+        unquote(opts[:pad]) |> PadModel.get_data!(:caps, unquote(state))
       end
 
     super(state, old_caps: old_caps)

--- a/lib/membrane/element/callback_context/caps.ex
+++ b/lib/membrane/element/callback_context/caps.ex
@@ -12,10 +12,10 @@ defmodule Membrane.Element.CallbackContext.Caps do
     old_caps: Membrane.Caps.t()
 
   @impl true
-  defmacro from_state(state, opts) do
+  defmacro from_state(state, args) do
     old_caps =
       quote do
-        unquote(opts[:pad]) |> PadModel.get_data!(:caps, unquote(state))
+        unquote(args[:pad]) |> PadModel.get_data!(:caps, unquote(state))
       end
 
     super(state, old_caps: old_caps)

--- a/lib/membrane/element/callback_context/pad_added.ex
+++ b/lib/membrane/element/callback_context/pad_added.ex
@@ -5,5 +5,5 @@ defmodule Membrane.Element.CallbackContext.PadAdded do
   """
   use Membrane.Element.CallbackContext,
     direction: :input | :output,
-    opts: keyword()
+    opts: any()
 end

--- a/lib/membrane/element/callback_context/pad_added.ex
+++ b/lib/membrane/element/callback_context/pad_added.ex
@@ -4,5 +4,6 @@ defmodule Membrane.Element.CallbackContext.PadAdded do
   when new pad added is created
   """
   use Membrane.Element.CallbackContext,
-    direction: :input | :output
+    direction: :input | :output,
+    opts: keyword()
 end

--- a/lib/membrane/element/pad.ex
+++ b/lib/membrane/element/pad.ex
@@ -44,13 +44,13 @@ defmodule Membrane.Element.Pad do
   may lead to overflow of element process erlang queue, which is highly unwanted.
   - `:pull` output pad - element can send data through such pad only if it have
   already received demand on the pad. Sending small, limited amount of
-  undemanded data is supported and handled by `Membrane.Core.PullBuffer`.
+  undemanded data is supported and handled by `Membrane.Core.InputBuffer`.
   - `:pull` input pad - element receives through such pad only data that it has
   previously demanded, so that no undemanded data can arrive.
 
   Linking pads with different modes is possible, but only in case of output pad
   working in push mode, and input in pull mode. Moreover, toilet mode of
-  `Membrane.Core.PullBuffer` has to be enabled then.
+  `Membrane.Core.InputBuffer` has to be enabled then.
 
   For more information on transfering data and demands, see docs for element
   callbacks in `Membrane.Element.Base.*`.

--- a/lib/membrane/element/pad_data.ex
+++ b/lib/membrane/element/pad_data.ex
@@ -3,11 +3,13 @@ defmodule Membrane.Element.Pad.Data do
   Struct describing current pad state.
 
   The public fields are:
-    - `caps` - `Membrane.Caps` on the pad (may be `nil` if not yet set)
-    - `start_of_stream?` - flag determining whether `Membrane.Event.StartOfStream`
-      has been received on the pad
-    - `end_of_stream?` - flag determining whether `Membrane.Event.EndOfStream`
-      has been received on the pad
+    - `:caps` - the last `Membrane.Caps` sent (output) or received (input) on the pad.
+      May be `nil` if not yet set.
+    - `:start_of_stream?` - flag determining whether `Membrane.Event.StartOfStream`
+      has been received (or sent) on the pad
+    - `:end_of_stream?` - flag determining whether `Membrane.Event.EndOfStream`
+      has been received (or sent) on the pad
+    - `:opts` - options passed in `Membrane.Pipeline.Spec` when linking pad
 
   Other fields in the struct ARE NOT PART OF THE PUBLIC API and should not be
   accessed or relied on.
@@ -23,17 +25,17 @@ defmodule Membrane.Element.Pad.Data do
           availability: Pad.availability_t(),
           direction: Pad.direction_t(),
           mode: Pad.mode_t(),
-          demand_unit: Metric.unit_t(),
-          other_demand_unit: Metric.unit_t(),
-          current_id: non_neg_integer,
+          demand_unit: Metric.unit_t() | nil,
+          other_demand_unit: Metric.unit_t() | nil,
+          current_id: non_neg_integer | nil,
           pid: pid,
           other_ref: Pad.ref_t(),
           caps: Caps.t() | nil,
           start_of_stream?: boolean(),
           end_of_stream?: boolean(),
           sticky_messages: [Event.t()],
-          buffer: PullBuffer.t(),
-          demand: integer(),
+          buffer: PullBuffer.t() | nil,
+          demand: integer() | nil,
           opts: any()
         }
 

--- a/lib/membrane/element/pad_data.ex
+++ b/lib/membrane/element/pad_data.ex
@@ -33,7 +33,8 @@ defmodule Membrane.Element.Pad.Data do
           end_of_stream?: boolean(),
           sticky_messages: [Event.t()],
           buffer: PullBuffer.t(),
-          demand: integer()
+          demand: integer(),
+          opts: any()
         }
 
   defstruct [
@@ -51,6 +52,7 @@ defmodule Membrane.Element.Pad.Data do
     :end_of_stream?,
     :sticky_messages,
     :buffer,
-    :demand
+    :demand,
+    :opts
   ]
 end

--- a/lib/membrane/element/pad_data.ex
+++ b/lib/membrane/element/pad_data.ex
@@ -3,8 +3,8 @@ defmodule Membrane.Element.Pad.Data do
   Struct describing current pad state.
 
   The public fields are:
-    - `:caps` - the last `Membrane.Caps` sent (output) or received (input) on the pad.
-      May be `nil` if not yet set.
+    - `:caps` - the most recent `Membrane.Caps` that have been sent (output) or received (input)
+      on the pad. May be `nil` if not yet set.
     - `:start_of_stream?` - flag determining whether `Membrane.Event.StartOfStream`
       has been received (or sent) on the pad
     - `:end_of_stream?` - flag determining whether `Membrane.Event.EndOfStream`
@@ -17,7 +17,7 @@ defmodule Membrane.Element.Pad.Data do
   alias Membrane.Element.Pad
   alias Membrane.{Buffer, Caps, Core, Event}
   alias Buffer.Metric
-  alias Core.PullBuffer
+  alias Core.InputBuffer
   use Bunch.Access
 
   @type t :: %__MODULE__{
@@ -34,7 +34,7 @@ defmodule Membrane.Element.Pad.Data do
           start_of_stream?: boolean(),
           end_of_stream?: boolean(),
           sticky_messages: [Event.t()],
-          buffer: PullBuffer.t() | nil,
+          buffer: InputBuffer.t() | nil,
           demand: integer() | nil,
           opts: any()
         }

--- a/lib/membrane/event_protocol.ex
+++ b/lib/membrane/event_protocol.ex
@@ -24,7 +24,7 @@ defprotocol Membrane.EventProtocol do
 
   Buffers and sync events are always received in the same order they are
   sent. Async events are handled before any enqueued buffers that are waiting to
-  be processed (e.g. in `Membrane.PullBuffer`).
+  be processed (e.g. in `Membrane.InputBuffer`).
   """
   @spec async?(t) :: boolean
   def async?(_event)

--- a/lib/membrane/helper/genserver.ex
+++ b/lib/membrane/helper/genserver.ex
@@ -1,7 +1,6 @@
 defmodule Membrane.Helper.GenServer do
-  @moduledoc """
-  Functions useful for constructing return values for GenServer based modules
-  """
+  @moduledoc false
+
   use Membrane.Log, tags: :core
 
   def noreply({:ok, new_state}), do: {:noreply, new_state}

--- a/lib/membrane/log/logger.ex
+++ b/lib/membrane/log/logger.ex
@@ -96,26 +96,7 @@ defmodule Membrane.Log.Logger do
       ) do
     module.handle_log(level, content, time, tags, internal_state)
     |> handle_callback(state)
-    |> format_callback_response(:noreply)
-  end
-
-  # Function is not private to prevent dialyzer from complaining about
-  # unused clauses
-  @doc false
-  def format_callback_response({:ok, new_state}, :reply) do
-    {:reply, :ok, new_state}
-  end
-
-  def format_callback_response({:ok, new_state}, :noreply) do
-    {:noreply, new_state}
-  end
-
-  def format_callback_response({:error, reason, new_state}, :reply) do
-    {:reply, {:error, reason}, new_state}
-  end
-
-  def format_callback_response({:error, reason, new_state}, :noreply) do
-    {:stop, [log_error: reason], new_state}
+    |> Membrane.Helper.GenServer.noreply()
   end
 
   # Generic handler that can be used to convert return value from
@@ -138,7 +119,7 @@ defmodule Membrane.Log.Logger do
         {:ok, %{state | internal_state: new_internal_state}}
 
       {:error, reason, new_internal_state} ->
-        {:error, reason, %{state | internal_state: new_internal_state}}
+        {{:error, reason}, %{state | internal_state: new_internal_state}}
 
       invalid_callback ->
         raise """

--- a/lib/membrane/pipeline.ex
+++ b/lib/membrane/pipeline.ex
@@ -8,7 +8,7 @@ defmodule Membrane.Pipeline do
   and process it in different ways.
   """
 
-  alias __MODULE__.{State, Spec}
+  alias __MODULE__.{Link, State, Spec}
   alias Membrane.{Core, Element, Notification}
   alias Element.Pad
   alias Core.{Message, Playback}
@@ -62,16 +62,6 @@ defmodule Membrane.Pipeline do
   @type callback_return_t :: CallbackHandler.callback_return_t(action_t, State.internal_state_t())
 
   @typep parsed_child_t :: %{name: Element.name_t(), module: module, options: Keyword.t()}
-  @typep parsed_link_t :: %{
-           from: %{element: Element.name_t(), pad: Pad.name_t()},
-           to: %{element: Element.name_t(), pad: Pad.name_t()},
-           params: [Spec.link_option_t()]
-         }
-  @typep resolved_link_t :: %{
-           from: %{element: Element.name_t(), pad: Pad.ref_t()},
-           to: %{element: Element.name_t(), pad: Pad.ref_t()},
-           params: [Spec.link_option_t()]
-         }
 
   @doc """
   Enables to check whether module is membrane pipeline
@@ -263,7 +253,7 @@ defmodule Membrane.Pipeline do
          {{:ok, children}, state} <- {parsed_children |> start_children, state},
          {:ok, state} <- children |> add_children(state),
          {{:ok, links}, state} <- {links |> parse_links, state},
-         {{:ok, links}, state} <- links |> resolve_links(state),
+         {{:ok, links}, state} <- {links |> resolve_links(state), state},
          {:ok, state} <- {links |> link_children(state), state},
          {children_names, children_pids} = children |> Enum.unzip(),
          {:ok, state} <- {children_pids |> set_children_watcher, state},
@@ -350,59 +340,26 @@ defmodule Membrane.Pipeline do
     end)
   end
 
-  @spec parse_links(Spec.links_spec_t() | any) :: Type.try_t([parsed_link_t])
-  defp parse_links(links), do: links |> Bunch.Enum.try_map(&parse_link/1)
+  @spec parse_links(Spec.links_spec_t() | any) :: Type.try_t([Link.t()])
+  defp parse_links(links), do: links |> Bunch.Enum.try_map(&Link.parse/1)
 
-  defp parse_link({{from, from_pad}, {to, to_pad, params}}) do
-    do_parse_link(from, from_pad, to, to_pad, params)
-  end
-
-  defp parse_link({{from, from_pad}, {to, to_pad}}) do
-    do_parse_link(from, from_pad, to, to_pad, [])
-  end
-
-  defp parse_link(link) do
-    {:error, {:invalid_link, link}}
-  end
-
-  defp do_parse_link(from, from_pad, to, to_pad, params) do
-    link = %{
-      from: %{element: from, pad: from_pad},
-      to: %{element: to, pad: to_pad},
-      params: params
-    }
-
-    with :ok <- [from_pad, to_pad] |> Bunch.Enum.try_each(&validate_pad_name/1) do
-      {:ok, link}
-    else
-      {:error, reason} -> {:error, {:invalid_link, link, reason}}
-    end
-  end
-
-  @spec validate_pad_name(atom | any) :: Type.try_t()
-  defp validate_pad_name(name) when Pad.is_pad_name(name) do
-    :ok
-  end
-
-  defp validate_pad_name(pad), do: {:error, {:invalid_pad_format, pad}}
-
-  @spec resolve_links([parsed_link_t], State.t()) ::
-          Type.stateful_try_t([resolved_link_t], State.t())
+  @spec resolve_links([Link.t()], State.t()) ::
+          Type.stateful_try_t([Link.resolved_t()], State.t())
   defp resolve_links(links, state) do
     links
-    |> Bunch.Enum.try_map_reduce(state, fn %{from: from, to: to} = link, st ->
-      with {{:ok, from}, st} <- from |> resolve_link(st),
-           {{:ok, to}, st} <- to |> resolve_link(st),
-           do: {{:ok, %{link | from: from, to: to}}, st}
+    |> Bunch.Enum.try_map(fn %{from: from, to: to} = link ->
+      with {:ok, from} <- from |> resolve_link(state),
+           {:ok, to} <- to |> resolve_link(state),
+           do: {:ok, %{link | from: from, to: to}}
     end)
   end
 
-  defp resolve_link(%{element: element, pad: pad_name} = elementpad, state) do
+  defp resolve_link(%{element: element, pad_name: pad_name} = endpoint, state) do
     with {:ok, pid} <- state |> State.get_child_pid(element),
          {:ok, pad_ref} <- pid |> Message.call(:get_pad_ref, pad_name) do
-      {{:ok, %{element: element, pad: pad_ref}}, state}
+      {:ok, %{endpoint | pid: pid, pad_ref: pad_ref}}
     else
-      {:error, reason} -> {:error, {:resolve_link, elementpad, reason}}
+      {:error, reason} -> {:error, {:resolve_link, endpoint, reason}}
     end
   end
 
@@ -411,11 +368,11 @@ defmodule Membrane.Pipeline do
   #
   # Please note that this function is not atomic and in case of error there's
   # a chance that some of children will remain linked.
-  @spec link_children([resolved_link_t], State.t()) :: Type.try_t()
+  @spec link_children([Link.resolved_t()], State.t()) :: Type.try_t()
   defp link_children(links, state) do
     debug("Linking children: links = #{inspect(links)}")
 
-    with :ok <- links |> Bunch.Enum.try_each(&do_link_children(&1, state)),
+    with :ok <- links |> Bunch.Enum.try_each(&do_link_children/1),
          :ok <-
            state
            |> State.get_children()
@@ -423,10 +380,8 @@ defmodule Membrane.Pipeline do
          do: :ok
   end
 
-  defp do_link_children(%{from: from, to: to, params: params} = link, state) do
-    with {:ok, from_pid} <- state |> State.get_child_pid(from.element),
-         {:ok, to_pid} <- state |> State.get_child_pid(to.element),
-         :ok <- Element.link(from_pid, to_pid, from.pad, to.pad, params) do
+  defp do_link_children(link) do
+    with :ok <- Element.link(link) do
       :ok
     else
       {:error, reason} -> {:error, {:cannot_link, link, reason}}

--- a/lib/membrane/pipeline.ex
+++ b/lib/membrane/pipeline.ex
@@ -277,10 +277,11 @@ defmodule Membrane.Pipeline do
     end
   end
 
-  @spec parse_children(Spec.children_spec_t() | any) :: Type.try_t(parsed_child_t)
+  @spec parse_children(Spec.children_spec_t() | any) :: Type.try_t([parsed_child_t])
   defp parse_children(children) when is_map(children) or is_list(children),
     do: children |> Bunch.Enum.try_map(&parse_child/1)
 
+  @spec parse_child(any) :: Type.try_t(parsed_child_t)
   defp parse_child({name, %module{} = options})
        when Element.is_element_name(name) do
     {:ok, %{name: name, module: module, options: options}}
@@ -344,7 +345,7 @@ defmodule Membrane.Pipeline do
   defp parse_links(links), do: links |> Bunch.Enum.try_map(&Link.parse/1)
 
   @spec resolve_links([Link.t()], State.t()) ::
-          Type.stateful_try_t([Link.resolved_t()], State.t())
+          Type.try_t([Link.resolved_t()])
   defp resolve_links(links, state) do
     links
     |> Bunch.Enum.try_map(fn %{from: from, to: to} = link ->

--- a/lib/membrane/pipeline/link.ex
+++ b/lib/membrane/pipeline/link.ex
@@ -1,0 +1,75 @@
+defmodule Membrane.Pipeline.Link do
+  @moduledoc false
+
+  alias Membrane.Element.Pad
+  require Pad
+
+  @enforce_keys [:from, :to]
+  defstruct @enforce_keys
+
+  @type t() :: %__MODULE__{from: Endpoint.t(), to: Endpoint.t()}
+
+  @typep resolved_t :: %__MODULE__{
+           from: Endpoint.resolved_t(),
+           to: Endpoint.resolved_t()
+         }
+
+  defmodule Endpoint do
+    @moduledoc false
+
+    alias Membrane.Element
+    alias Membrane.Element.Pad
+
+    @enforce_keys [:element, :pad_name]
+    defstruct element: nil, pad_name: nil, pad_ref: nil, pid: nil, opts: []
+
+    @type t() :: %__MODULE__{
+            element: Element.name_t(),
+            pad_name: Pad.name_t(),
+            pad_ref: Pad.ref_t() | nil,
+            pid: pid() | nil,
+            opts: keyword()
+          }
+
+    @type resolved_t() :: %__MODULE__{
+            element: Element.name_t(),
+            pad_name: Pad.name_t(),
+            pad_ref: Pad.ref_t(),
+            pid: pid(),
+            opts: keyword()
+          }
+
+    @spec parse(Pipeline.link_spec_t() | any()) :: {:ok, t()} | {:error, any()}
+    def parse({elem, pad_name}) do
+      %__MODULE__{element: elem, pad_name: pad_name, opts: []} |> validate()
+    end
+
+    def parse({elem, pad_name, opts}) when is_list(opts) do
+      %__MODULE__{element: elem, pad_name: pad_name, opts: opts} |> validate()
+    end
+
+    def parse(endpoint) do
+      {:error, {:invalid_endpoint, endpoint}}
+    end
+
+    defp validate(%__MODULE__{pad_name: pad} = endpoint) do
+      if Pad.is_pad_name(pad) do
+        {:ok, endpoint}
+      else
+        {:error, {:invalid_pad_format, pad}}
+      end
+    end
+  end
+
+  @spec parse(Pipeline.links_spec_t() | any()) :: {:ok, t()} | {:error, any()}
+  def parse({from, to}) do
+    with {:ok, from} <- Endpoint.parse(from),
+         {:ok, to} <- Endpoint.parse(to) do
+      {:ok, %__MODULE__{from: from, to: to}}
+    end
+  end
+
+  def parse(link) do
+    {:error, {:invalid_link, link}}
+  end
+end

--- a/lib/membrane/pipeline/link.ex
+++ b/lib/membrane/pipeline/link.ex
@@ -19,7 +19,6 @@ defmodule Membrane.Pipeline.Link do
   defmodule Endpoint do
     @moduledoc false
 
-    alias Membrane.Core.PullBuffer
     alias Membrane.Element
     alias Membrane.Element.Pad
     alias Membrane.Pipeline
@@ -28,14 +27,13 @@ defmodule Membrane.Pipeline.Link do
     defstruct element: nil, pad_name: nil, pad_ref: nil, pid: nil, opts: []
 
     @valid_opt_keys [:pad, :buffer]
-    @type opts_t :: [{:pad, keyword() | map()} | {:buffer, PullBuffer.props_t()}]
 
     @type t() :: %__MODULE__{
             element: Element.name_t(),
             pad_name: Pad.name_t(),
             pad_ref: Pad.ref_t() | nil,
             pid: pid() | nil,
-            opts: opts_t()
+            opts: Pipeline.Spec.endpoint_options_t()
           }
 
     @type resolved_t() :: %__MODULE__{
@@ -43,7 +41,7 @@ defmodule Membrane.Pipeline.Link do
             pad_name: Pad.name_t(),
             pad_ref: Pad.ref_t(),
             pid: pid(),
-            opts: opts_t()
+            opts: Pipeline.Spec.endpoint_options_t()
           }
 
     @spec parse(Pipeline.Spec.link_endpoint_spec_t() | any()) :: {:ok, t()} | {:error, any()}

--- a/lib/membrane/pipeline/link.ex
+++ b/lib/membrane/pipeline/link.ex
@@ -9,10 +9,10 @@ defmodule Membrane.Pipeline.Link do
 
   @type t() :: %__MODULE__{from: Endpoint.t(), to: Endpoint.t()}
 
-  @typep resolved_t :: %__MODULE__{
-           from: Endpoint.resolved_t(),
-           to: Endpoint.resolved_t()
-         }
+  @type resolved_t :: %__MODULE__{
+          from: Endpoint.resolved_t(),
+          to: Endpoint.resolved_t()
+        }
 
   defmodule Endpoint do
     @moduledoc false

--- a/lib/membrane/pipeline/link.ex
+++ b/lib/membrane/pipeline/link.ex
@@ -2,6 +2,8 @@ defmodule Membrane.Pipeline.Link do
   @moduledoc false
 
   alias Membrane.Element.Pad
+  alias Membrane.Pipeline
+  alias __MODULE__.Endpoint
   require Pad
 
   @enforce_keys [:from, :to]
@@ -19,6 +21,7 @@ defmodule Membrane.Pipeline.Link do
 
     alias Membrane.Element
     alias Membrane.Element.Pad
+    alias Membrane.Pipeline
 
     @enforce_keys [:element, :pad_name]
     defstruct element: nil, pad_name: nil, pad_ref: nil, pid: nil, opts: []
@@ -39,7 +42,7 @@ defmodule Membrane.Pipeline.Link do
             opts: keyword()
           }
 
-    @spec parse(Pipeline.link_spec_t() | any()) :: {:ok, t()} | {:error, any()}
+    @spec parse(Pipeline.Spec.link_endpoint_spec_t() | any()) :: {:ok, t()} | {:error, any()}
     def parse({elem, pad_name}) do
       %__MODULE__{element: elem, pad_name: pad_name, opts: []} |> validate()
     end
@@ -61,7 +64,7 @@ defmodule Membrane.Pipeline.Link do
     end
   end
 
-  @spec parse(Pipeline.links_spec_t() | any()) :: {:ok, t()} | {:error, any()}
+  @spec parse(Pipeline.Spec.links_spec_t()) :: {:ok, t()} | {:error, any()}
   def parse({from, to}) do
     with {:ok, from} <- Endpoint.parse(from),
          {:ok, to} <- Endpoint.parse(to) do

--- a/lib/membrane/pipeline/spec.ex
+++ b/lib/membrane/pipeline/spec.ex
@@ -46,7 +46,7 @@ defmodule Membrane.Pipeline.Spec do
   """
 
   alias Membrane.Element
-  alias Membrane.Core.PullBuffer
+  alias Membrane.Core.InputBuffer
   alias Element.Pad
 
   @type child_spec_t :: module | struct
@@ -62,12 +62,12 @@ defmodule Membrane.Pipeline.Spec do
   Options passed to the element when linking its pad with different one.
 
   The allowed options are:
-  * `:buffer` - keywoed allowing to configure PullBuffer between elements. Valid only for input pads.
-    See `t:Membrane.Core.PullBuffer.props_t/0` for configurable properties.
+  * `:buffer` - keywoed allowing to configure `Membrane.Core.InputBuffer` between elements. Valid only for input pads.
+    See `t:Membrane.Core.InputBuffer.props_t/0` for configurable properties.
   * `:pad` - any element-specific options that will be available in `Membrane.Element.Pad.Data` struct.
   """
   @type endpoint_options_t :: [
-          {:buffer, PullBuffer.props_t()} | {:pad, element_specific_opts :: any()}
+          {:buffer, InputBuffer.props_t()} | {:pad, element_specific_opts :: any()}
         ]
 
   @typedoc """

--- a/lib/membrane/pipeline/spec.ex
+++ b/lib/membrane/pipeline/spec.ex
@@ -11,8 +11,8 @@ defmodule Membrane.Pipeline.Spec do
   Children that should be spawned when the pipeline starts can be defined
   with the `:children` field.
 
-  You have to set it to a keyword list, where keys are valid element name
-  that is unique within this pipeline and values are either element's module or
+  You have to set it to a keyword list, where keys are valid element names (`t:Membrane.Element.name_t/0`)
+  that are unique within this pipeline and values are either element's module or
   struct of that module.
 
   Sample definitions:
@@ -23,16 +23,6 @@ defmodule Membrane.Pipeline.Spec do
         other_element: Element.Using.Default.Options
       ]
 
-  When defining children, some additional parameters can be provided by wrapping
-  child definition with a tuple and putting keyword list of parameters at the end:
-
-      [
-        first_element: {Element.Bare, indexed: true},
-        second_element: {%Element{opt_a: 42}, indexed: true}
-      ]
-
-  Available params are described in `t:child_property_t/0`
-
   ## Links
 
   Links that should be made when the pipeline starts, and children are spawned
@@ -40,7 +30,7 @@ defmodule Membrane.Pipeline.Spec do
 
   You have to set it to a map, where both keys and values are tuples of
   `{element_name, pad_name}`. Entries can also have additional options passed by
-  keyword list at the end of a tuple (See `t:endpoint_option_t/0`).
+  keyword list at the end of a tuple (See `t:endpoint_options_t/0`).
   Element names have to match names given to the `:children` field.
 
   Once it's done, pipeline will ensure that links are present.
@@ -48,10 +38,10 @@ defmodule Membrane.Pipeline.Spec do
   Sample definition:
 
       %{
-        {:source_a,   :output} => {:converter,  :input, buffer: [preferred_size: 20_000]},
-        {:converter,  :output} => {:mixer, :input_a},
-        {:source_b,   :output} => {:mixer, :input_b, pad: [mute: true]}
-        {:mixer,      :output} => {:sink,  :input, buffer: []},
+        {:source_a, :output} => {:converter, :input, buffer: [preferred_size: 20_000]},
+        {:converter, :output} => {:mixer, :input_a},
+        {:source_b, :output} => {:mixer, :input_b, pad: [mute: true]}
+        {:mixer, :output} => {:sink, :input, buffer: [warn_size: 264_000, fail_size: 300_000]},
       }
   """
 
@@ -72,9 +62,9 @@ defmodule Membrane.Pipeline.Spec do
   Options passed to the element when linking its pad with different one.
 
   The allowed options are:
-  * `:buffer` - allows to configure Buffer between elements. Valid only for input pads.
-    See `t:Membrane.Core.PullBuffer.props_t/0`
-  * `:pad` - any element-specific options that will be available in pad data
+  * `:buffer` - keywoed allowing to configure PullBuffer between elements. Valid only for input pads.
+    See `t:Membrane.Core.PullBuffer.props_t/0` for configurable properties.
+  * `:pad` - any element-specific options that will be available in `Membrane.Element.Pad.Data` struct.
   """
   @type endpoint_options_t :: [
           {:buffer, PullBuffer.props_t()} | {:pad, element_specific_opts :: any()}

--- a/lib/membrane/testing/source.ex
+++ b/lib/membrane/testing/source.ex
@@ -4,14 +4,15 @@ defmodule Membrane.Testing.Source do
   """
 
   use Membrane.Element.Base.Source
-  alias Membrane.Buffer
   use Bunch
+  alias Membrane.Buffer
+  alias Membrane.Element.Action
 
   def_output_pads output: [caps: :any]
 
   def_options actions_generator: [
                 type: :function,
-                spec: (non_neg_integer, non_neg_integer -> [Membrane.Action.t()]),
+                spec: (non_neg_integer, non_neg_integer -> [Action.t()]),
                 default: &__MODULE__.default_buf_gen/2,
                 description: """
                 Function invoked each time `handle_demand` is invoked.

--- a/lib/membrane/time.ex
+++ b/lib/membrane/time.ex
@@ -121,7 +121,7 @@ defmodule Membrane.Time do
   @doc """
   Returns string representation of result of `to_code/1`.
   """
-  @spec pretty_duration(t) :: Macro.t()
+  @spec to_code_str(t) :: Macro.t()
   def to_code_str(time) when is_t(time) do
     time |> to_code() |> Macro.to_string()
   end

--- a/spec/membrane/core/element/pad_controller_spec.exs
+++ b/spec/membrane/core/element/pad_controller_spec.exs
@@ -4,7 +4,7 @@ defmodule Membrane.Core.Element.PadControllerSpec do
   alias Membrane.Core.Element.{PadModel, PadSpecHandler, State}
   alias Membrane.Event.EndOfStream
 
-  describe ".link_pad/6" do
+  describe ".link_pad/7" do
     let :module, do: TrivialFilter
     let :name, do: :element_name
 
@@ -17,29 +17,34 @@ defmodule Membrane.Core.Element.PadControllerSpec do
       let :pad_name, do: :output
       let :direction, do: :output
       let :other_ref, do: :other_input
+      let :other_info, do: nil
       let :props, do: %{}
 
-      it "should return an ok result" do
+      it "should return an ok result with pad info" do
+        pad_info = state().pads.info.output
+
         expect(
           described_module().handle_link(
             pad_ref(),
             direction(),
             self(),
             other_ref(),
+            other_info(),
             props(),
             state()
           )
         )
-        |> to(be_ok_result())
+        |> to(match_pattern {{:ok, ^pad_info}, _})
       end
 
       it "should remove given pad from pads.info" do
-        {:ok, new_state} =
+        {{:ok, _info}, new_state} =
           described_module().handle_link(
             pad_ref(),
             direction(),
             self(),
             other_ref(),
+            other_info(),
             props(),
             state()
           )
@@ -48,12 +53,13 @@ defmodule Membrane.Core.Element.PadControllerSpec do
       end
 
       it "should not modify state except pads list" do
-        {:ok, new_state} =
+        {{:ok, _info}, new_state} =
           described_module().handle_link(
             pad_ref(),
             direction(),
             self(),
             other_ref(),
+            other_info(),
             props(),
             state()
           )
@@ -62,12 +68,13 @@ defmodule Membrane.Core.Element.PadControllerSpec do
       end
 
       it "should add pad to the 'pads.data' list" do
-        {:ok, new_state} =
+        {{:ok, _info}, new_state} =
           described_module().handle_link(
             pad_ref(),
             direction(),
             self(),
             other_ref(),
+            other_info(),
             props(),
             state()
           )
@@ -80,6 +87,7 @@ defmodule Membrane.Core.Element.PadControllerSpec do
       let :pad_ref, do: :invalid_ref
       let :direction, do: :output
       let :other_ref, do: :other_input
+      let :other_info, do: nil
       let :props, do: %{}
 
       it "should return an error result" do
@@ -89,6 +97,7 @@ defmodule Membrane.Core.Element.PadControllerSpec do
             direction(),
             self(),
             other_ref(),
+            other_info(),
             props(),
             state()
           )

--- a/spec/membrane/core/input_buffer_spec.exs
+++ b/spec/membrane/core/input_buffer_spec.exs
@@ -1,5 +1,5 @@
-defmodule Membrane.Core.PullBufferSpec do
-  alias Membrane.Core.{PullBuffer, Message}
+defmodule Membrane.Core.InputBufferSpec do
+  alias Membrane.Core.{InputBuffer, Message}
   alias Membrane.Testing.Event
   require Message
   alias Membrane.Buffer
@@ -29,17 +29,23 @@ defmodule Membrane.Core.PullBufferSpec do
       do: [
         preferred_size: preferred_size(),
         min_demand: min_demand(),
-        toilet: toilet(),
         warn_size: warn_size(),
         fail_size: fail_size()
       ]
 
-    it "should return PullBuffer struct and send demand message" do
+    it "should return InputBuffer struct and send demand message" do
       expect(
-        described_module().new(name(), demand_pid(), linked_output_ref(), demand_unit(), props())
+        described_module().new(
+          name(),
+          demand_pid(),
+          linked_output_ref(),
+          demand_unit(),
+          toilet(),
+          props()
+        )
       )
       |> to(
-        eq(%PullBuffer{
+        eq(%InputBuffer{
           name: name(),
           demand_pid: demand_pid(),
           linked_output_ref: linked_output_ref(),
@@ -68,11 +74,12 @@ defmodule Membrane.Core.PullBufferSpec do
             demand_pid(),
             linked_output_ref(),
             demand_unit(),
+            toilet(),
             props()
           )
         )
         |> to(
-          eq(%PullBuffer{
+          eq(%InputBuffer{
             name: name(),
             demand_pid: demand_pid(),
             linked_output_ref: linked_output_ref(),
@@ -94,7 +101,7 @@ defmodule Membrane.Core.PullBufferSpec do
     let :current_size, do: 0
 
     let :pb,
-      do: %PullBuffer{
+      do: %InputBuffer{
         current_size: current_size(),
         metric: Buffer.Metric.Count,
         q: Qex.new()
@@ -122,7 +129,7 @@ defmodule Membrane.Core.PullBufferSpec do
     let :metric, do: Buffer.Metric.Count
 
     let :pb,
-      do: %PullBuffer{
+      do: %InputBuffer{
         current_size: current_size(),
         metric: metric(),
         q: q()
@@ -184,7 +191,7 @@ defmodule Membrane.Core.PullBufferSpec do
     let :metric, do: Buffer.Metric.Count
 
     let :pb,
-      do: %PullBuffer{
+      do: %InputBuffer{
         current_size: current_size(),
         demand: 0,
         min_demand: 0,

--- a/spec/membrane/element_spec.exs
+++ b/spec/membrane/element_spec.exs
@@ -90,7 +90,7 @@ defmodule Membrane.ElementSpec do
           |> to(be_error_result())
         end
 
-        fit "should return :invalid_pad_direction as a reason" do
+        it "should return :invalid_pad_direction as a reason" do
           {:error, val} = described_module().link(link_struct())
           {:handle_call, {:cannot_handle_message, [message: _, mode: _, reason: reason]}} = val
           expect(reason) |> to(eq {:invalid_pad_direction, [expected: :output, actual: :input]})

--- a/spec/support/element/trivial_pipeline.ex
+++ b/spec/support/element/trivial_pipeline.ex
@@ -11,8 +11,8 @@ defmodule Membrane.Support.Element.TrivialPipeline do
     ]
 
     links = %{
-      {:producer, :output} => {:filter, :input, pull_buffer: [preferred_size: 10]},
-      {:filter, :output} => {:consumer, :input, pull_buffer: [preferred_size: 10]}
+      {:producer, :output} => {:filter, :input, buffer: [preferred_size: 10]},
+      {:filter, :output} => {:consumer, :input, buffer: [preferred_size: 10]}
     }
 
     spec = %Pipeline.Spec{

--- a/test/membrane/pipeline/link_test.exs
+++ b/test/membrane/pipeline/link_test.exs
@@ -1,0 +1,55 @@
+defmodule Membrane.Pipeline.LinkTest do
+  use ExUnit.Case
+  alias Membrane.Pipeline.Link
+  alias Link.Endpoint
+
+  @moduletag :focus
+
+  test "Endpoint parsing" do
+    assert Endpoint.parse({:source, :input}) ==
+             {:ok, %Endpoint{element: :source, pad_name: :input, opts: []}}
+
+    assert Endpoint.parse({{:source, 42}, :input}) ==
+             {:ok, %Endpoint{element: {:source, 42}, pad_name: :input, opts: []}}
+
+    assert Endpoint.parse({:source, :input, opt: true}) ==
+             {:ok, %Endpoint{element: :source, pad_name: :input, opts: [opt: true]}}
+
+    assert Endpoint.parse({:source}) ==
+             {:error, {:invalid_endpoint, {:source}}}
+
+    assert Endpoint.parse({:source, 42}) ==
+             {:error, {:invalid_pad_format, 42}}
+  end
+
+  def test_valid_link(raw_from, raw_to) do
+    assert {:ok, %Link{from: from, to: to}} = Link.parse({raw_from, raw_to})
+    assert {:ok, from} == Endpoint.parse(raw_from)
+    assert {:ok, to} == Endpoint.parse(raw_to)
+  end
+
+  def test_invalid_link(raw_from, raw_to) do
+    assert Link.parse({raw_from, raw_to}) == Endpoint.parse(raw_from)
+  end
+
+  test "Link parsing" do
+    valid_end = {:source, :input}
+    valid_end_opt = {:source, :input, opt: true}
+    invalid_end = {:source}
+    invalid_pad = {:source, 42}
+
+    test_valid_link(valid_end, valid_end)
+    test_valid_link(valid_end_opt, valid_end)
+    test_valid_link(valid_end, valid_end_opt)
+    test_valid_link(valid_end_opt, valid_end_opt)
+
+    assert Link.parse({invalid_end, valid_end}) == Endpoint.parse(invalid_end)
+    assert Link.parse({valid_end, invalid_end}) == Endpoint.parse(invalid_end)
+
+    assert Link.parse({invalid_pad, valid_end}) == Endpoint.parse(invalid_pad)
+    assert Link.parse({valid_end, invalid_pad}) == Endpoint.parse(invalid_pad)
+
+    not_link = {:not, :a, :link}
+    assert Link.parse(not_link) == {:error, {:invalid_link, not_link}}
+  end
+end

--- a/test/membrane/pipeline/link_test.exs
+++ b/test/membrane/pipeline/link_test.exs
@@ -12,8 +12,8 @@ defmodule Membrane.Pipeline.LinkTest do
     assert Endpoint.parse({{:source, 42}, :input}) ==
              {:ok, %Endpoint{element: {:source, 42}, pad_name: :input, opts: []}}
 
-    assert Endpoint.parse({:source, :input, opt: true}) ==
-             {:ok, %Endpoint{element: :source, pad_name: :input, opts: [opt: true]}}
+    assert Endpoint.parse({:source, :input, pad: [mute: true]}) ==
+             {:ok, %Endpoint{element: :source, pad_name: :input, opts: [pad: [mute: true]]}}
 
     assert Endpoint.parse({:source}) ==
              {:error, {:invalid_endpoint, {:source}}}
@@ -34,7 +34,7 @@ defmodule Membrane.Pipeline.LinkTest do
 
   test "Link parsing" do
     valid_end = {:source, :input}
-    valid_end_opt = {:source, :input, opt: true}
+    valid_end_opt = {:source, :input, pad: [mute: true]}
     invalid_end = {:source}
     invalid_pad = {:source, 42}
 

--- a/test/support/demands_test/pipeline.ex
+++ b/test/support/demands_test/pipeline.ex
@@ -10,8 +10,8 @@ defmodule Membrane.Support.DemandsTest.Pipeline do
     ]
 
     links = %{
-      {:source, :output} => {:filter, :input, pull_buffer: [preferred_size: 50]},
-      {:filter, :output} => {:sink, :input, pull_buffer: [preferred_size: 50]}
+      {:source, :output} => {:filter, :input, buffer: [preferred_size: 50]},
+      {:filter, :output} => {:sink, :input, buffer: [preferred_size: 50]}
     }
 
     spec = %Pipeline.Spec{


### PR DESCRIPTION
This PR adds a possibility to pass some options to a pad (both input and output) and closes #139. Here's an example:
```elixir
    links = %{
      {:file_src_a, :output} => {:decoder, :input},
      {:decoder, :output} => {:mixer, :input, pad: [mute: false]},
      {:file_src_b, :output} => {:mixer, :input, pad: [hello: :b]},
      {:file_src_c, :output} => {:mixer, :input},
      {:file_src_d, :output} => {:mixer, :input},
      {:mixer, :output} =>
        {:converter, :input, buffer: [preferred_size: 264_600]},
      {:converter, :output} => {:sink, :input}
    }
```
The options are available in `handle_pad_added` callback context:
```elixir
  @impl true
  def handle_pad_added(pad, %{opts: pad_opts}, state) do
    state =
      state
      |> Bunch.Access.put_in([:outputs, pad], %{
        queue: <<>>,
        sos: false,
        eos: false,
        skip: 0,
        mute:
          if pad_opts[:mute] != nil do
            pad_opts[:mute]
          else
            state.mute_by_default
          end
      })

    {:ok, state}
  end
```
From any other callback they can be accessed by `ctx.pads[:pad_ref].opts` (applies to static pads as well)

Other changes: 
* `:pull_buffer` options now become simply `:buffer`. <- I'm open for discussion whether it's OK
* `:toilet` option is added automatically for push output -> pull input link (should it generate a warning?)
* linking pull output and push input will generate error (closes #39)
* `pull_buffer: [toilet: [warn: 42, fail: 84]]` becomes `buffer: [warn_size: 42, fail_size: 84]` or we can use the default rules of warn_size = 2 * preferred_size and fail_size = 4 * preferred_size and write:
 `buffer: [preferred_size: 21]` (closes #132)