### PR TITLE
Child removal

### DIFF
--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -209,7 +209,7 @@ defmodule Membrane.Core.Element.ActionHandler do
         pad_data
 
       state = handle_buffer(pad_ref, mode, other_demand_unit, buffers, state)
-      Message.send(pid, :buffer, [buffers, other_ref])
+      Message.send(pid, :buffer, [buffers], from_pad: other_ref)
       {:ok, state}
     else
       buffers: {:error, buf} -> {{:error, {:invalid_buffer, buf}}, state}
@@ -257,7 +257,7 @@ defmodule Membrane.Core.Element.ActionHandler do
 
       state = state |> PadModel.set_data!(pad_ref, :caps, caps)
 
-      Message.send(pid, :caps, [caps, other_ref])
+      Message.send(pid, :caps, [caps], from_pad: other_ref)
       {:ok, state}
     else
       pad: {:error, reason} -> {{:error, reason}, state}
@@ -346,7 +346,7 @@ defmodule Membrane.Core.Element.ActionHandler do
     withl event: true <- event |> Event.event?(),
           pad: {:ok, %{pid: pid, other_ref: other_ref}} <- PadModel.get_data(state, pad_ref),
           handler: {:ok, state} <- handle_event(pad_ref, event, state) do
-      Message.send(pid, :event, [event, other_ref])
+      Message.send(pid, :event, [event], from_pad: other_ref)
       {:ok, state}
     else
       event: false -> {{:error, {:invalid_event, event}}, state}

--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -209,7 +209,7 @@ defmodule Membrane.Core.Element.ActionHandler do
         pad_data
 
       state = handle_buffer(pad_ref, mode, other_demand_unit, buffers, state)
-      Message.send(pid, :buffer, [buffers], from_pad: other_ref)
+      Message.send(pid, :buffer, buffers, from_pad: other_ref)
       {:ok, state}
     else
       buffers: {:error, buf} -> {{:error, {:invalid_buffer, buf}}, state}
@@ -257,7 +257,7 @@ defmodule Membrane.Core.Element.ActionHandler do
 
       state = state |> PadModel.set_data!(pad_ref, :caps, caps)
 
-      Message.send(pid, :caps, [caps], from_pad: other_ref)
+      Message.send(pid, :caps, caps, from_pad: other_ref)
       {:ok, state}
     else
       pad: {:error, reason} -> {{:error, reason}, state}
@@ -346,7 +346,7 @@ defmodule Membrane.Core.Element.ActionHandler do
     withl event: true <- event |> Event.event?(),
           pad: {:ok, %{pid: pid, other_ref: other_ref}} <- PadModel.get_data(state, pad_ref),
           handler: {:ok, state} <- handle_event(pad_ref, event, state) do
-      Message.send(pid, :event, [event], from_pad: other_ref)
+      Message.send(pid, :event, event, from_pad: other_ref)
       {:ok, state}
     else
       event: false -> {{:error, {:invalid_event, event}}, state}

--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -209,7 +209,7 @@ defmodule Membrane.Core.Element.ActionHandler do
         pad_data
 
       state = handle_buffer(pad_ref, mode, other_demand_unit, buffers, state)
-      Message.send(pid, :buffer, buffers, from_pad: other_ref)
+      Message.send(pid, :buffer, buffers, for_pad: other_ref)
       {:ok, state}
     else
       buffers: {:error, buf} -> {{:error, {:invalid_buffer, buf}}, state}
@@ -257,7 +257,7 @@ defmodule Membrane.Core.Element.ActionHandler do
 
       state = state |> PadModel.set_data!(pad_ref, :caps, caps)
 
-      Message.send(pid, :caps, caps, from_pad: other_ref)
+      Message.send(pid, :caps, caps, for_pad: other_ref)
       {:ok, state}
     else
       pad: {:error, reason} -> {{:error, reason}, state}
@@ -346,7 +346,7 @@ defmodule Membrane.Core.Element.ActionHandler do
     withl event: true <- event |> Event.event?(),
           pad: {:ok, %{pid: pid, other_ref: other_ref}} <- PadModel.get_data(state, pad_ref),
           handler: {:ok, state} <- handle_event(pad_ref, event, state) do
-      Message.send(pid, :event, event, from_pad: other_ref)
+      Message.send(pid, :event, event, for_pad: other_ref)
       {:ok, state}
     else
       event: false -> {{:error, {:invalid_event, event}}, state}

--- a/lib/membrane/core/element/lifecycle_controller.ex
+++ b/lib/membrane/core/element/lifecycle_controller.ex
@@ -134,6 +134,7 @@ defmodule Membrane.Core.Element.LifecycleController do
   @impl PlaybackHandler
   def handle_playback_state_changed(_old, :stopped, %State{terminating: true} = state) do
     unlink(state.pads.data)
+    Message.send(state.watcher, :shutdown_ready, state.name)
     {:ok, state}
   end
 

--- a/lib/membrane/core/element/lifecycle_controller.ex
+++ b/lib/membrane/core/element/lifecycle_controller.ex
@@ -132,11 +132,8 @@ defmodule Membrane.Core.Element.LifecycleController do
   end
 
   @impl PlaybackHandler
-  def handle_playback_state_changed(_old, :stopped, %State{terminating: true} = state) do
-    unlink(state.pads.data)
-    Message.send(state.watcher, :shutdown_ready, state.name)
-    {:ok, state}
-  end
+  def handle_playback_state_changed(_old, :stopped, %State{terminating: true} = state),
+    do: prepare_shutdown(state)
 
   @impl PlaybackHandler
   def handle_playback_state_changed(_old, _new, state) do

--- a/lib/membrane/core/element/message_dispatcher.ex
+++ b/lib/membrane/core/element/message_dispatcher.ex
@@ -70,9 +70,9 @@ defmodule Membrane.Core.Element.MessageDispatcher do
   end
 
   # incoming demands, buffers, caps, events from other element
-  defp do_handle_message(Message.new(type, args), :info, state)
+  defp do_handle_message(Message.new(type, _args, _opts) = msg, :info, state)
        when type in [:demand, :buffer, :caps, :event] do
-    {type, args} |> PlaybackBuffer.store(state)
+    msg |> PlaybackBuffer.store(state)
   end
 
   defp do_handle_message(Message.new(:get_pad_ref, [pad_name, id]), :call, state) do

--- a/lib/membrane/core/element/pad_controller.ex
+++ b/lib/membrane/core/element/pad_controller.ex
@@ -92,8 +92,8 @@ defmodule Membrane.Core.Element.PadController do
   """
   @spec handle_unlink(Pad.ref_t(), State.t()) :: State.stateful_try_t()
   def handle_unlink(pad_ref, state) do
-    with {:ok, state} <- generate_eos_if_needed(pad_ref, state),
-         {:ok, state} <- maybe_flush_playback_buffer(pad_ref, state),
+    with {:ok, state} <- maybe_flush_playback_buffer(pad_ref, state),
+         {:ok, state} <- generate_eos_if_needed(pad_ref, state),
          {:ok, state} <- handle_pad_removed(pad_ref, state),
          {:ok, state} <- PadModel.delete_data(state, pad_ref) do
       {:ok, state}
@@ -353,7 +353,8 @@ defmodule Membrane.Core.Element.PadController do
 
     case direction do
       :input ->
-        {:ok, %{state | playback_buffer: PlaybackBuffer.new()}}
+        new_playback_buf = PlaybackBuffer.flush_for_pad(state.playback_buffer, pad_ref)
+        {:ok, %{state | playback_buffer: new_playback_buf}}
 
       _ ->
         {:ok, state}

--- a/lib/membrane/core/element/pad_controller.ex
+++ b/lib/membrane/core/element/pad_controller.ex
@@ -92,7 +92,7 @@ defmodule Membrane.Core.Element.PadController do
   """
   @spec handle_unlink(Pad.ref_t(), State.t()) :: State.stateful_try_t()
   def handle_unlink(pad_ref, state) do
-    with {:ok, state} <- maybe_flush_playback_buffer(pad_ref, state),
+    with {:ok, state} <- flush_playback_buffer(pad_ref, state),
          {:ok, state} <- generate_eos_if_needed(pad_ref, state),
          {:ok, state} <- handle_pad_removed(pad_ref, state),
          {:ok, state} <- PadModel.delete_data(state, pad_ref) do
@@ -348,16 +348,8 @@ defmodule Membrane.Core.Element.PadController do
     end
   end
 
-  defp maybe_flush_playback_buffer(pad_ref, state) do
-    direction = PadModel.get_data!(state, pad_ref, :direction)
-
-    case direction do
-      :input ->
-        new_playback_buf = PlaybackBuffer.flush_for_pad(state.playback_buffer, pad_ref)
-        {:ok, %{state | playback_buffer: new_playback_buf}}
-
-      _ ->
-        {:ok, state}
-    end
+  defp flush_playback_buffer(pad_ref, state) do
+    new_playback_buf = PlaybackBuffer.flush_for_pad(state.playback_buffer, pad_ref)
+    {:ok, %{state | playback_buffer: new_playback_buf}}
   end
 end

--- a/lib/membrane/core/element/pad_controller.ex
+++ b/lib/membrane/core/element/pad_controller.ex
@@ -4,7 +4,7 @@ defmodule Membrane.Core.Element.PadController do
 
   alias Membrane.{Core, Event, ElementLinkError}
   alias Core.{CallbackHandler, Message, InputBuffer}
-  alias Core.Element.{ActionHandler, EventController, PadModel, State}
+  alias Core.Element.{ActionHandler, EventController, PadModel, State, PlaybackBuffer}
   alias Membrane.Element.{CallbackContext, Pad}
   require CallbackContext.{PadAdded, PadRemoved}
   require Message
@@ -88,10 +88,12 @@ defmodule Membrane.Core.Element.PadController do
   Removes pad data.
   Signals an EoS (via handle_event) to the element if unlinked pad was an input.
   Executes `handle_pad_removed` callback if the pad was dynamic.
+  Note: it also flushes all buffers from PlaybackBuffer.
   """
   @spec handle_unlink(Pad.ref_t(), State.t()) :: State.stateful_try_t()
   def handle_unlink(pad_ref, state) do
     with {:ok, state} <- generate_eos_if_needed(pad_ref, state),
+         {:ok, state} <- maybe_flush_playback_buffer(pad_ref, state),
          {:ok, state} <- handle_pad_removed(pad_ref, state),
          {:ok, state} <- PadModel.delete_data(state, pad_ref) do
       {:ok, state}
@@ -343,6 +345,18 @@ defmodule Membrane.Core.Element.PadController do
       )
     else
       {:ok, state}
+    end
+  end
+
+  defp maybe_flush_playback_buffer(pad_ref, state) do
+    direction = PadModel.get_data!(state, pad_ref, :direction)
+
+    case direction do
+      :input ->
+        {:ok, %{state | playback_buffer: PlaybackBuffer.new()}}
+
+      _ ->
+        {:ok, state}
     end
   end
 end

--- a/lib/membrane/core/element/playback_buffer.ex
+++ b/lib/membrane/core/element/playback_buffer.ex
@@ -95,7 +95,7 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
 
   @spec exec(message_t, State.t()) :: State.stateful_try_t()
   # Callback invoked on demand request coming from the output pad in the pull mode
-  defp exec(Message.new(:demand, [size], _opts) = msg, state) do
+  defp exec(Message.new(:demand, size, _opts) = msg, state) do
     pad_ref = Message.from_pad(msg)
     PadModel.assert_data!(state, pad_ref, %{direction: :output})
 
@@ -111,7 +111,7 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
   end
 
   # Callback invoked on buffer coming through the input pad
-  defp exec(Message.new(:buffer, [buffers], _opts) = msg, state) do
+  defp exec(Message.new(:buffer, buffers, _opts) = msg, state) do
     pad_ref = Message.from_pad(msg)
     PadModel.assert_data!(state, pad_ref, %{direction: :input})
 
@@ -140,7 +140,7 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
   end
 
   # Callback invoked on incoming caps
-  defp exec(Message.new(:caps, [caps], _opts) = msg, state) do
+  defp exec(Message.new(:caps, caps, _opts) = msg, state) do
     pad_ref = Message.from_pad(msg)
     PadModel.assert_data!(state, pad_ref, %{direction: :input})
 
@@ -156,7 +156,7 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
   end
 
   # Callback invoked on incoming event
-  defp exec(Message.new(:event, [event], _opts) = msg, state) do
+  defp exec(Message.new(:event, event, _opts) = msg, state) do
     pad_ref = Message.from_pad(msg)
     PadModel.assert_instance!(state, pad_ref)
 

--- a/lib/membrane/core/element/playback_buffer.ex
+++ b/lib/membrane/core/element/playback_buffer.ex
@@ -85,7 +85,7 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
     require Message
 
     q
-    |> Enum.filter(fn msg -> Message.from_pad(msg) != pad_ref end)
+    |> Enum.filter(fn msg -> Message.for_pad(msg) != pad_ref end)
     |> Enum.into(%@qe{})
     ~> %{buf | q: &1}
   end
@@ -96,7 +96,7 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
   @spec exec(message_t, State.t()) :: State.stateful_try_t()
   # Callback invoked on demand request coming from the output pad in the pull mode
   defp exec(Message.new(:demand, size, _opts) = msg, state) do
-    pad_ref = Message.from_pad(msg)
+    pad_ref = Message.for_pad(msg)
     PadModel.assert_data!(state, pad_ref, %{direction: :output})
 
     demand =
@@ -112,7 +112,7 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
 
   # Callback invoked on buffer coming through the input pad
   defp exec(Message.new(:buffer, buffers, _opts) = msg, state) do
-    pad_ref = Message.from_pad(msg)
+    pad_ref = Message.for_pad(msg)
     PadModel.assert_data!(state, pad_ref, %{direction: :input})
 
     debug(
@@ -141,7 +141,7 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
 
   # Callback invoked on incoming caps
   defp exec(Message.new(:caps, caps, _opts) = msg, state) do
-    pad_ref = Message.from_pad(msg)
+    pad_ref = Message.for_pad(msg)
     PadModel.assert_data!(state, pad_ref, %{direction: :input})
 
     debug(
@@ -157,7 +157,7 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
 
   # Callback invoked on incoming event
   defp exec(Message.new(:event, event, _opts) = msg, state) do
-    pad_ref = Message.from_pad(msg)
+    pad_ref = Message.for_pad(msg)
     PadModel.assert_instance!(state, pad_ref)
 
     debug(

--- a/lib/membrane/core/element/playback_buffer.ex
+++ b/lib/membrane/core/element/playback_buffer.ex
@@ -77,6 +77,16 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
 
   def eval(state), do: {:ok, state}
 
+  def flush_for_pad(%__MODULE__{q: q} = buf, pad_ref) do
+    q
+    |> Enum.filter(fn
+      {_, [_, ^pad_ref]} -> false
+      e -> e
+    end)
+    |> Enum.into(%@qe{})
+    ~> %{buf | q: &1}
+  end
+
   @spec empty?(t) :: boolean
   defp empty?(%__MODULE__{q: q}), do: q |> Enum.empty?()
 

--- a/lib/membrane/core/element/playback_buffer.ex
+++ b/lib/membrane/core/element/playback_buffer.ex
@@ -15,7 +15,9 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
     PadModel,
     State
   }
+  alias Membrane.Core.Message
 
+  require Message
   require PadModel
   use Core.Element.Log
   use Bunch
@@ -42,7 +44,7 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
   @spec store(message_t, State.t()) :: State.stateful_try_t()
   def store(msg, %State{playback: %Playback{state: :playing}} = state), do: exec(msg, state)
 
-  def store({type, _args} = msg, state)
+  def store(Message.new(type, _args, _opts) = msg, state)
       when type in [:event, :caps] do
     if state.playback_buffer |> empty? do
       exec(msg, state)
@@ -92,7 +94,7 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
 
   @spec exec(message_t, State.t()) :: State.stateful_try_t()
   # Callback invoked on demand request coming from the output pad in the pull mode
-  defp exec({:demand, [size, pad_ref]}, state) do
+  defp exec(Message.new(:demand, [size, pad_ref], _opts), state) do
     PadModel.assert_data!(state, pad_ref, %{direction: :output})
 
     demand =
@@ -107,7 +109,7 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
   end
 
   # Callback invoked on buffer coming through the input pad
-  defp exec({:buffer, [buffers, pad_ref]}, state) do
+  defp exec(Message.new(:buffer, [buffers, pad_ref], _opts), state) do
     PadModel.assert_data!(state, pad_ref, %{direction: :input})
 
     debug(
@@ -135,7 +137,7 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
   end
 
   # Callback invoked on incoming caps
-  defp exec({:caps, [caps, pad_ref]}, state) do
+  defp exec(Message.new(:caps, [caps, pad_ref], _opts), state) do
     PadModel.assert_data!(state, pad_ref, %{direction: :input})
 
     debug(
@@ -150,7 +152,7 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
   end
 
   # Callback invoked on incoming event
-  defp exec({:event, [event, pad_ref]}, state) do
+  defp exec(Message.new(:event, [event, pad_ref], _opts), state) do
     PadModel.assert_instance!(state, pad_ref)
 
     debug(

--- a/lib/membrane/core/input_buffer.ex
+++ b/lib/membrane/core/input_buffer.ex
@@ -255,7 +255,7 @@ defmodule Membrane.Core.InputBuffer do
       input_buf
     )
 
-    Message.send(demand_pid, :demand, to_demand, from_pad: linked_output_ref)
+    Message.send(demand_pid, :demand, to_demand, for_pad: linked_output_ref)
     %__MODULE__{input_buf | demand: demand - to_demand}
   end
 

--- a/lib/membrane/core/input_buffer.ex
+++ b/lib/membrane/core/input_buffer.ex
@@ -255,7 +255,7 @@ defmodule Membrane.Core.InputBuffer do
       input_buf
     )
 
-    Message.send(demand_pid, :demand, [to_demand, linked_output_ref])
+    Message.send(demand_pid, :demand, [to_demand], from_pad: linked_output_ref)
     %__MODULE__{input_buf | demand: demand - to_demand}
   end
 

--- a/lib/membrane/core/input_buffer.ex
+++ b/lib/membrane/core/input_buffer.ex
@@ -255,7 +255,7 @@ defmodule Membrane.Core.InputBuffer do
       input_buf
     )
 
-    Message.send(demand_pid, :demand, [to_demand], from_pad: linked_output_ref)
+    Message.send(demand_pid, :demand, to_demand, from_pad: linked_output_ref)
     %__MODULE__{input_buf | demand: demand - to_demand}
   end
 

--- a/lib/membrane/core/message.ex
+++ b/lib/membrane/core/message.ex
@@ -32,5 +32,5 @@ defmodule Membrane.Core.Message do
     GenServer.call(pid, message(type: type, args: args, opts: opts), timeout)
   end
 
-  def from_pad(message(opts: opts)), do: Keyword.get(opts, :from_pad)
+  def for_pad(message(opts: opts)), do: Keyword.get(opts, :for_pad)
 end

--- a/lib/membrane/core/message.ex
+++ b/lib/membrane/core/message.ex
@@ -4,30 +4,31 @@ defmodule Membrane.Core.Message do
 
   require Record
 
-  Record.defrecord(:message, __MODULE__, type: nil, args: [])
+  Record.defrecord(:message, __MODULE__, type: nil, args: [], opts: [])
 
   @type t :: {__MODULE__, type_t, args_t}
   @type type_t :: atom
   @type args_t :: list | any
+  @type opts_t :: Keyword.t()
 
-  defmacro new(type, args \\ []) do
+  defmacro new(type, args \\ [], opts \\ []) do
     quote do
-      unquote(__MODULE__).message(type: unquote(type), args: unquote(args))
+      unquote(__MODULE__).message(type: unquote(type), args: unquote(args), opts: unquote(opts))
     end
   end
 
-  @spec send(pid, type_t, args_t) :: t
-  def send(pid, type, args \\ []) do
-    Kernel.send(pid, message(type: type, args: args))
+  @spec send(pid, type_t, args_t, opts_t) :: t
+  def send(pid, type, args \\ [], opts \\ []) do
+    Kernel.send(pid, message(type: type, args: args, opts: opts))
   end
 
-  @spec self(type_t, args_t) :: t
-  def self(type, args \\ []) do
-    __MODULE__.send(self(), type, args)
+  @spec self(type_t, args_t, opts_t) :: t
+  def self(type, args \\ [], opts \\ []) do
+    __MODULE__.send(self(), type, args, opts)
   end
 
   @spec call(GenServer.server(), type_t, args_t, timeout()) :: term()
-  def call(pid, type, args \\ [], timeout \\ 5000) do
-    GenServer.call(pid, message(type: type, args: args), timeout)
+  def call(pid, type, args \\ [], opts \\ [], timeout \\ 5000) do
+    GenServer.call(pid, message(type: type, args: args, opts: opts), timeout)
   end
 end

--- a/lib/membrane/core/message.ex
+++ b/lib/membrane/core/message.ex
@@ -31,4 +31,6 @@ defmodule Membrane.Core.Message do
   def call(pid, type, args \\ [], opts \\ [], timeout \\ 5000) do
     GenServer.call(pid, message(type: type, args: args, opts: opts), timeout)
   end
+
+  def from_pad(message(opts: opts)), do: Keyword.get(opts, :from_pad)
 end

--- a/lib/membrane/element.ex
+++ b/lib/membrane/element.ex
@@ -146,7 +146,7 @@ defmodule Membrane.Element do
   """
   @spec set_watcher(pid, pid, timeout) :: :ok
   def set_watcher(server, watcher, timeout \\ 5000) when is_pid(server) do
-    Message.call(server, :set_watcher, watcher, timeout)
+    Message.call(server, :set_watcher, watcher, [], timeout)
   end
 
   @doc """
@@ -157,7 +157,7 @@ defmodule Membrane.Element do
   """
   @spec set_controlling_pid(pid, pid, timeout) :: :ok | {:error, any}
   def set_controlling_pid(server, controlling_pid, timeout \\ 5000) when is_pid(server) do
-    Message.call(server, :set_controlling_pid, controlling_pid, timeout)
+    Message.call(server, :set_controlling_pid, controlling_pid, [], timeout)
   end
 
   @doc """
@@ -204,14 +204,14 @@ defmodule Membrane.Element do
   `:on_request` pad.
   """
   def handle_new_pad(server, direction, pad, timeout \\ 5000) when is_pid(server) do
-    server |> Message.call(:new_pad, [direction, pad], timeout)
+    server |> Message.call(:new_pad, [direction, pad], [], timeout)
   end
 
   @doc """
   Sends synchronous call to element, informing it that linking has finished.
   """
   def handle_linking_finished(server, timeout \\ 5000) when is_pid(server) do
-    server |> Message.call(:linking_finished, [], timeout)
+    server |> Message.call(:linking_finished, [], [], timeout)
   end
 
   @impl GenServer

--- a/lib/membrane/pipeline.ex
+++ b/lib/membrane/pipeline.ex
@@ -503,7 +503,9 @@ defmodule Membrane.Pipeline do
 
   def handle_info(Message.new(:shutdown_ready, child), state) do
     {{:ok, pid}, state} = State.pop_child(state, child)
+
     {Element.shutdown(pid), state}
+    |> noreply(state)
   end
 
   def handle_info(message, state) do

--- a/lib/membrane/testing/pipeline.ex
+++ b/lib/membrane/testing/pipeline.ex
@@ -48,13 +48,12 @@ defmodule Membrane.Testing.Pipeline do
   You can also pass a custom pipeline module, by using `:module` field of
   `Membrane.Testing.Pipeline.Options` struct. Every callback of the module
   will be executed before the callbacks of Testing.Pipeline.
+  Passed module has to return a proper spec. There should be no elements
+  nor links specified in options passed to test pipeline as that would
+  result in a failure.
 
   ```
   options = %Membrane.Testing.Pipeline.Options {
-    elements: [
-      el1: MembraneElement1,
-      el2: MembraneElement2,
-      ],
       module: Your.Module
     }
     ```

--- a/spec/membrane/core/input_buffer_spec.exs
+++ b/spec/membrane/core/input_buffer_spec.exs
@@ -57,8 +57,8 @@ defmodule Membrane.Core.InputBufferSpec do
       )
 
       pad_ref = linked_output_ref()
-      expected_list = [preferred_size()]
-      assert_received Message.new(:demand, ^expected_list, from_pad: ^pad_ref)
+      expected_size = preferred_size()
+      assert_received Message.new(:demand, ^expected_size, from_pad: ^pad_ref)
     end
 
     context "if toilet is not false" do
@@ -238,9 +238,9 @@ defmodule Membrane.Core.InputBufferSpec do
           linked_output_ref()
         )
 
-        expected_list = [current_size()]
+        expected_size = current_size()
         pad_ref = linked_output_ref()
-        assert_received Message.new(:demand, ^expected_list, from_pad: ^pad_ref)
+        assert_received Message.new(:demand, ^expected_size, from_pad: ^pad_ref)
       end
     end
 

--- a/spec/membrane/core/input_buffer_spec.exs
+++ b/spec/membrane/core/input_buffer_spec.exs
@@ -56,8 +56,9 @@ defmodule Membrane.Core.InputBufferSpec do
         })
       )
 
-      expected_list = [preferred_size(), linked_output_ref()]
-      assert_received Message.new(:demand, ^expected_list)
+      pad_ref = linked_output_ref()
+      expected_list = [preferred_size()]
+      assert_received Message.new(:demand, ^expected_list, from_pad: ^pad_ref)
     end
 
     context "if toilet is not false" do
@@ -237,8 +238,9 @@ defmodule Membrane.Core.InputBufferSpec do
           linked_output_ref()
         )
 
-        expected_list = [current_size(), linked_output_ref()]
-        assert_received Message.new(:demand, ^expected_list)
+        expected_list = [current_size()]
+        pad_ref = linked_output_ref()
+        assert_received Message.new(:demand, ^expected_list, from_pad: ^pad_ref)
       end
     end
 
@@ -261,7 +263,7 @@ defmodule Membrane.Core.InputBufferSpec do
           exp_list = Qex.new() |> Qex.push(buffers2()) |> Enum.into([])
 
           expect(list) |> to(eq exp_list)
-          assert_received Message.new(:demand, _)
+          assert_received Message.new(:demand, _, _)
         end
       end
 
@@ -285,7 +287,7 @@ defmodule Membrane.Core.InputBufferSpec do
           exp_list = Qex.new() |> Qex.push(exp_rest) |> Enum.into([])
 
           expect(list) |> to(eq exp_list)
-          assert_received Message.new(:demand, _)
+          assert_received Message.new(:demand, _, _)
         end
       end
     end

--- a/spec/membrane/core/input_buffer_spec.exs
+++ b/spec/membrane/core/input_buffer_spec.exs
@@ -58,7 +58,7 @@ defmodule Membrane.Core.InputBufferSpec do
 
       pad_ref = linked_output_ref()
       expected_size = preferred_size()
-      assert_received Message.new(:demand, ^expected_size, from_pad: ^pad_ref)
+      assert_received Message.new(:demand, ^expected_size, for_pad: ^pad_ref)
     end
 
     context "if toilet is not false" do
@@ -240,7 +240,7 @@ defmodule Membrane.Core.InputBufferSpec do
 
         expected_size = current_size()
         pad_ref = linked_output_ref()
-        assert_received Message.new(:demand, ^expected_size, from_pad: ^pad_ref)
+        assert_received Message.new(:demand, ^expected_size, for_pad: ^pad_ref)
       end
     end
 

--- a/test/membrane/core/element/action_handler_test.exs
+++ b/test/membrane/core/element/action_handler_test.exs
@@ -155,7 +155,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
 
       assert result == {:ok, state}
-      assert_received Message.new(:buffer, [[@mock_buffer]], from_pad: :other_ref)
+      assert_received Message.new(:buffer, [@mock_buffer], from_pad: :other_ref)
     end
 
     test "when element is playing", %{state: state} do
@@ -170,7 +170,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
 
       assert result == {:ok, state}
-      assert_received Message.new(:buffer, [[@mock_buffer]], from_pad: :other_ref)
+      assert_received Message.new(:buffer, [@mock_buffer], from_pad: :other_ref)
     end
 
     test "when pad doesn't exist in the element", %{state: state} do
@@ -273,7 +273,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
 
       assert result == {:ok, state |> PadModel.set_data!(:output, :end_of_stream?, true)}
-      assert_received Message.new(:event, [@mock_event], from_pad: :other_ref)
+      assert_received Message.new(:event, @mock_event, from_pad: :other_ref)
     end
 
     test "when pad doesn't exist in the element", %{state: state} do
@@ -377,7 +377,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
 
       assert result == {:ok, state |> PadModel.set_data!(:output, :caps, @mock_caps)}
-      assert_received Message.new(:caps, [@mock_caps], from_pad: :other_ref)
+      assert_received Message.new(:caps, @mock_caps, from_pad: :other_ref)
     end
 
     test "when caps doesn't match specs", %{state: state} do
@@ -395,7 +395,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
       end
 
-      refute_received Message.new(:caps, [@mock_caps, :other_ref])
+      refute_received Message.new(:caps, @mock_caps, from_pad: :other_ref)
     end
 
     test "invalid pad direction", %{state: state} do
@@ -410,7 +410,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
       end
 
-      refute_received Message.new(:caps, [@mock_caps, :other_ref])
+      refute_received Message.new(:caps, @mock_caps, from_pad: :other_ref)
     end
   end
 

--- a/test/membrane/core/element/action_handler_test.exs
+++ b/test/membrane/core/element/action_handler_test.exs
@@ -155,7 +155,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
 
       assert result == {:ok, state}
-      assert_received Message.new(:buffer, [[@mock_buffer], :other_ref])
+      assert_received Message.new(:buffer, [[@mock_buffer]], from_pad: :other_ref)
     end
 
     test "when element is playing", %{state: state} do
@@ -170,7 +170,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
 
       assert result == {:ok, state}
-      assert_received Message.new(:buffer, [[@mock_buffer], :other_ref])
+      assert_received Message.new(:buffer, [[@mock_buffer]], from_pad: :other_ref)
     end
 
     test "when pad doesn't exist in the element", %{state: state} do
@@ -273,7 +273,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
 
       assert result == {:ok, state |> PadModel.set_data!(:output, :end_of_stream?, true)}
-      assert_received Message.new(:event, [@mock_event, :other_ref])
+      assert_received Message.new(:event, [@mock_event], from_pad: :other_ref)
     end
 
     test "when pad doesn't exist in the element", %{state: state} do
@@ -377,7 +377,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
 
       assert result == {:ok, state |> PadModel.set_data!(:output, :caps, @mock_caps)}
-      assert_received Message.new(:caps, [@mock_caps, :other_ref])
+      assert_received Message.new(:caps, [@mock_caps], from_pad: :other_ref)
     end
 
     test "when caps doesn't match specs", %{state: state} do

--- a/test/membrane/core/element/action_handler_test.exs
+++ b/test/membrane/core/element/action_handler_test.exs
@@ -155,7 +155,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
 
       assert result == {:ok, state}
-      assert_received Message.new(:buffer, [@mock_buffer], from_pad: :other_ref)
+      assert_received Message.new(:buffer, [@mock_buffer], for_pad: :other_ref)
     end
 
     test "when element is playing", %{state: state} do
@@ -170,7 +170,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
 
       assert result == {:ok, state}
-      assert_received Message.new(:buffer, [@mock_buffer], from_pad: :other_ref)
+      assert_received Message.new(:buffer, [@mock_buffer], for_pad: :other_ref)
     end
 
     test "when pad doesn't exist in the element", %{state: state} do
@@ -273,7 +273,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
 
       assert result == {:ok, state |> PadModel.set_data!(:output, :end_of_stream?, true)}
-      assert_received Message.new(:event, @mock_event, from_pad: :other_ref)
+      assert_received Message.new(:event, @mock_event, for_pad: :other_ref)
     end
 
     test "when pad doesn't exist in the element", %{state: state} do
@@ -377,7 +377,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
 
       assert result == {:ok, state |> PadModel.set_data!(:output, :caps, @mock_caps)}
-      assert_received Message.new(:caps, @mock_caps, from_pad: :other_ref)
+      assert_received Message.new(:caps, @mock_caps, for_pad: :other_ref)
     end
 
     test "when caps doesn't match specs", %{state: state} do
@@ -395,7 +395,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
       end
 
-      refute_received Message.new(:caps, @mock_caps, from_pad: :other_ref)
+      refute_received Message.new(:caps, @mock_caps, for_pad: :other_ref)
     end
 
     test "invalid pad direction", %{state: state} do
@@ -410,7 +410,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
       end
 
-      refute_received Message.new(:caps, @mock_caps, from_pad: :other_ref)
+      refute_received Message.new(:caps, @mock_caps, for_pad: :other_ref)
     end
   end
 

--- a/test/membrane/core/element/caps_controller_test.exs
+++ b/test/membrane/core/element/caps_controller_test.exs
@@ -35,7 +35,7 @@ defmodule Membrane.Core.Element.CapsControllerTest do
       }
       |> Bunch.Struct.put_in([:playback, :state], :playing)
 
-    assert_received Message.new(:demand, [10], from_pad: :some_pad)
+    assert_received Message.new(:demand, 10, from_pad: :some_pad)
     [state: state]
   end
 

--- a/test/membrane/core/element/caps_controller_test.exs
+++ b/test/membrane/core/element/caps_controller_test.exs
@@ -35,7 +35,7 @@ defmodule Membrane.Core.Element.CapsControllerTest do
       }
       |> Bunch.Struct.put_in([:playback, :state], :playing)
 
-    assert_received Message.new(:demand, [10, :some_pad])
+    assert_received Message.new(:demand, [10], from_pad: :some_pad)
     [state: state]
   end
 

--- a/test/membrane/core/element/caps_controller_test.exs
+++ b/test/membrane/core/element/caps_controller_test.exs
@@ -35,7 +35,7 @@ defmodule Membrane.Core.Element.CapsControllerTest do
       }
       |> Bunch.Struct.put_in([:playback, :state], :playing)
 
-    assert_received Message.new(:demand, 10, from_pad: :some_pad)
+    assert_received Message.new(:demand, 10, for_pad: :some_pad)
     [state: state]
   end
 

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -157,7 +157,6 @@ defmodule Membrane.Integration.ChildRemovalTest do
 
   defp assert_pid_alive(pid) do
     refute_receive {:DOWN, _, :process, ^pid, _}
-    assert Process.alive?(pid)
   end
 
   defp get_filter_pid(ref, pipeline_pid) do

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -180,7 +180,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
   defp wait_for_buffer_fillup(el_pid, for_pads, timeout \\ 5) do
     1..10
     |> Enum.take_while(fn _ ->
-      :timer.sleep(timeout)
+      Process.sleep(timeout)
 
       %PlaybackBuffer{q: q} = :sys.get_state(el_pid).playback_buffer
 

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -187,7 +187,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
       pads_in_buffer =
         q
         |> Enum.filter(fn Message.new(type, _, _) -> type == :buffer end)
-        |> Enum.map(fn Message.new(_, _, opts) -> Keyword.get(opts, :from_pad) end)
+        |> Enum.map(fn Message.new(_, _, opts) -> Keyword.get(opts, :for_pad) end)
         |> Enum.dedup()
         |> Enum.sort()
 

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -217,7 +217,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
     |> Enum.all?(&buffer_with_name?(&1, source))
   end
 
-  defp buffer_with_name?([list], name),
+  defp buffer_with_name?(list, name),
     do: Enum.all?(list, fn %Buffer{metadata: %{source_name: name2}} -> name == name2 end)
 
   defp wait_for_playing(el_pid) do

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -111,7 +111,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
                                   /
                  extra_source ___/
   """
-  test "When PlaybackBuffer is evaluated elements from the other than deleted elements remain untouched" do
+  test "When element is removed data sent from it is removed from neighbours' playback buffer, other data remain untouched" do
     source_buf_gen = get_named_buf_gen(:source)
     extra_source_buf_gen = get_named_buf_gen(:extra_source)
 

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -217,9 +217,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
     |> Enum.all?(&buffer_with_name?(&1, source))
   end
 
-  defp buffer_with_name?([%Buffer{metadata: %{source_name: name}}], name), do: true
-
-  defp buffer_with_name?([list, _pad], name),
+  defp buffer_with_name?([list], name),
     do: Enum.all?(list, fn %Buffer{metadata: %{source_name: name2}} -> name == name2 end)
 
   defp wait_for_playing(el_pid) do

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -2,6 +2,8 @@ defmodule Membrane.Integration.ChildRemovalTest do
   use ExUnit.Case, async: false
   use Bunch
   alias Membrane.Support.ChildRemovalTest
+  alias Membrane.Core.Element.PlaybackBuffer
+  alias Membrane.Buffer
   alias ChildRemovalTest.Filter
   alias Membrane.Testing.{Source, Sink}
   alias Membrane.Pipeline
@@ -93,6 +95,47 @@ defmodule Membrane.Integration.ChildRemovalTest do
     stop_pipeline(pid)
   end
 
+  test "When PlaybackBuffer is evaluated elements from the other than deleted elements remain untouched" do
+    source_buf_gen = get_named_buf_gen(:source)
+    extra_source_buf_gen = get_named_buf_gen(:extra_source)
+
+    assert {:ok, pid} =
+             Pipeline.start_link(ChildRemovalTest.Pipeline, %{
+               source: %Source{actions_generator: source_buf_gen},
+               extra_source: %Source{actions_generator: extra_source_buf_gen},
+               filter1: %Filter{target: self(), ref: 1},
+               filter2: %Filter{
+                 target: self(),
+                 playing_delay: prepared_to_playing_delay(),
+                 ref: 2
+               },
+               sink: %Sink{target: self(), autodemand: false},
+               target: self()
+             })
+
+    [filter_pid1, filter_pid2] =
+      [1, 2]
+      |> Enum.map(&get_filter_pid/1)
+
+    assert Pipeline.play(pid) == :ok
+    wait_for_neighbours_state_change()
+    send(pid, {:child_msg, :sink, {:make_demand, 30}})
+    wait_for_buffer_fillup()
+
+    send(pid, {:remove_child, :filter1})
+
+    assert_receive :element_shutting_down
+    assert_pid_dead(filter_pid1)
+
+    %PlaybackBuffer{q: q} = :sys.get_state(filter_pid2).playback_buffer
+    refute Enum.empty?(q)
+    assert all_buffers_from?(q, :extra_source)
+
+    assert_pid_alive(filter_pid2)
+
+    stop_pipeline(pid)
+  end
+
   defp stop_pipeline(pid) do
     assert Pipeline.stop(pid) == :ok
     assert_receive :pipeline_stopped, 500
@@ -118,4 +161,27 @@ defmodule Membrane.Integration.ChildRemovalTest do
   defp wait_for_buffer_fillup, do: :timer.sleep(round(prepared_to_playing_delay() / 3))
 
   defp wait_for_neighbours_state_change, do: :timer.sleep(round(prepared_to_playing_delay() / 3))
+
+  defp get_named_buf_gen(name) do
+    fn cnt, size ->
+      cnt..(size + cnt - 1)
+      |> Enum.map(fn _cnt ->
+        buf = %Buffer{payload: 'a', metadata: %{source_name: name}}
+        {:buffer, {:output, buf}}
+      end)
+      ~> {&1, cnt + size}
+    end
+  end
+
+  defp all_buffers_from?(q, source) do
+    q
+    |> Enum.filter(fn {el_name, _} -> el_name == :buffer end)
+    |> Enum.map(fn {:buffer, buf} -> buf end)
+    |> Enum.all?(&buffer_with_name?(&1, source))
+  end
+
+  defp buffer_with_name?([%Buffer{metadata: %{source_name: name}}, _pad], name), do: true
+
+  defp buffer_with_name?([list, _pad], name),
+    do: Enum.all?(list, fn %Buffer{metadata: %{source_name: name2}} -> name == name2 end)
 end

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -168,7 +168,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
 
   defp prepared_to_playing_delay, do: 300
 
-  # Checks if there is at least one buffer element for each pad specified in `for_pads`
+  # Checks if there is at least one item in the playback buffer for each pad specified in `for_pads`
   defp wait_for_buffer_fillup(el_pid, for_pads, timeout \\ 5) do
     1..10
     |> Enum.take_while(fn _ ->

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -85,6 +85,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
     wait_for_neighbours_state_change()
     send(pid, {:child_msg, :sink, {:make_demand, 30}})
     wait_for_buffer_fillup()
+    Filter.deactivate_demands_on_input(filter_pid2)
 
     send(pid, {:remove_child, :filter1})
 
@@ -121,6 +122,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
     wait_for_neighbours_state_change()
     send(pid, {:child_msg, :sink, {:make_demand, 30}})
     wait_for_buffer_fillup()
+    Filter.deactivate_demands_on_input(filter_pid2)
 
     send(pid, {:remove_child, :filter1})
 

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -48,9 +48,8 @@ defmodule Membrane.Integration.ChildRemovalTest do
       |> Enum.map(&get_filter_pid(&1, pipeline_pid))
 
     assert Pipeline.play(pipeline_pid) == :ok
-    assert_receive {:playing, ^pipeline_pid}
-    assert_receive {:playing, ^filter_pid1}
-    assert_receive {:playing, ^filter_pid2}
+    assert_receive {:playing, :filter1}
+    assert_receive {:playing, :filter2}
 
     ChildRemovalTest.Pipeline.remove_child(pipeline_pid, :filter1)
 
@@ -88,7 +87,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
       |> Enum.map(&get_filter_pid(&1, pipeline_pid))
 
     assert Pipeline.play(pipeline_pid) == :ok
-    wait_for_playing(filter_pid1)
+    wait_for_playing(:filter1)
     wait_for_buffer_fillup(filter_pid2, [:input1])
 
     ChildRemovalTest.Pipeline.remove_child(pipeline_pid, :filter1)
@@ -133,7 +132,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
       |> Enum.map(&get_filter_pid(&1, pipeline_pid))
 
     assert Pipeline.play(pipeline_pid) == :ok
-    wait_for_playing(filter_pid1)
+    wait_for_playing(:filter1)
     wait_for_buffer_fillup(filter_pid2, [:input1, :input2])
 
     ChildRemovalTest.Pipeline.remove_child(pipeline_pid, :filter1)
@@ -221,7 +220,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
   defp buffer_with_name?(list, name),
     do: Enum.all?(list, fn %Buffer{metadata: %{source_name: name2}} -> name == name2 end)
 
-  defp wait_for_playing(el_pid) do
-    assert_receive {:playing, ^el_pid}
+  defp wait_for_playing(el) do
+    assert_receive {:playing, ^el}
   end
 end

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -85,7 +85,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
     wait_for_neighbours_state_change()
     send(pid, {:child_msg, :sink, {:make_demand, 30}})
     wait_for_buffer_fillup()
-    Filter.deactivate_demands_on_input(filter_pid2)
+    Filter.deactivate_demands_on_input1(filter_pid2)
 
     send(pid, {:remove_child, :filter1})
 
@@ -122,7 +122,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
     wait_for_neighbours_state_change()
     send(pid, {:child_msg, :sink, {:make_demand, 30}})
     wait_for_buffer_fillup()
-    Filter.deactivate_demands_on_input(filter_pid2)
+    Filter.deactivate_demands_on_input1(filter_pid2)
 
     send(pid, {:remove_child, :filter1})
 

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -87,7 +87,6 @@ defmodule Membrane.Integration.ChildRemovalTest do
     assert Pipeline.play(pipeline_pid) == :ok
     wait_for_playing(filter_pid1)
     wait_for_buffer_fillup(filter_pid2, [:input1])
-    ChildRemovalTest.Filter.deactivate_demands_on_input1(filter_pid2)
 
     ChildRemovalTest.Pipeline.remove_child(pipeline_pid, :filter1)
 
@@ -133,7 +132,6 @@ defmodule Membrane.Integration.ChildRemovalTest do
     assert Pipeline.play(pipeline_pid) == :ok
     wait_for_playing(filter_pid1)
     wait_for_buffer_fillup(filter_pid2, [:input1, :input2])
-    ChildRemovalTest.Filter.deactivate_demands_on_input1(filter_pid2)
 
     ChildRemovalTest.Pipeline.remove_child(pipeline_pid, :filter1)
 

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -24,7 +24,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
 
     [filter_pid1, filter_pid2] =
       [:filter1, :filter2]
-      |> Enum.map(&get_filter_pid/1)
+      |> Enum.map(&get_filter_pid(&1, pipeline_pid))
 
     ChildRemovalTest.Pipeline.remove_child(pipeline_pid, :filter1)
 
@@ -45,7 +45,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
 
     [filter_pid1, filter_pid2] =
       [:filter1, :filter2]
-      |> Enum.map(&get_filter_pid/1)
+      |> Enum.map(&get_filter_pid(&1, pipeline_pid))
 
     assert Pipeline.play(pipeline_pid) == :ok
     assert_receive {:playing, ^pipeline_pid}
@@ -85,7 +85,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
 
     [filter_pid1, filter_pid2] =
       [:filter1, :filter2]
-      |> Enum.map(&get_filter_pid/1)
+      |> Enum.map(&get_filter_pid(&1, pipeline_pid))
 
     assert Pipeline.play(pipeline_pid) == :ok
     wait_for_playing(filter_pid1)
@@ -130,7 +130,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
 
     [filter_pid1, filter_pid2] =
       [:filter1, :filter2]
-      |> Enum.map(&get_filter_pid/1)
+      |> Enum.map(&get_filter_pid(&1, pipeline_pid))
 
     assert Pipeline.play(pipeline_pid) == :ok
     wait_for_playing(filter_pid1)
@@ -168,8 +168,9 @@ defmodule Membrane.Integration.ChildRemovalTest do
     assert Process.alive?(pid)
   end
 
-  defp get_filter_pid(ref) do
-    assert_receive {:filter_pid, ^ref, pid}
+  defp get_filter_pid(ref, pipeline_pid) do
+    state = :sys.get_state(pipeline_pid)
+    pid = state.children[ref]
     Process.monitor(pid)
     pid
   end

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -10,34 +10,35 @@ defmodule Membrane.Integration.ChildRemovalTest do
     assert {:ok, pid} =
              Pipeline.start_link(ChildRemovalTest.Pipeline, %{
                source: Source,
-               filter: %Filter{target: self()},
+               filter1: %Filter{target: self(), ref: 1},
+               filter2: %Filter{target: self(), ref: 2},
                sink: %Sink{target: self(), autodemand: false},
                target: self()
              })
 
-    assert_receive {:filter_pid, filter_pid}
-    assert Process.alive?(filter_pid)
+    [filter_pid1, filter_pid2] =
+    [1, 2]
+    |> Enum.map(&get_filter_pid/1)
 
-    send(pid, {:remove_child, :filter})
-    :timer.sleep(1000)
+    send(pid, {:remove_child, :filter1})
 
     assert_receive :element_shutting_down
-    refute Process.alive?(filter_pid)
-
-    assert Pipeline.stop(pid) == :ok
+    assert_pid_dead(filter_pid1)
+    assert Process.alive?(filter_pid2)
   end
 
   test "Element can be removed when pipeline is in playing state" do
     assert {:ok, pid} =
              Pipeline.start_link(ChildRemovalTest.Pipeline, %{
                source: Source,
-               filter: %Filter{target: self()},
+               filter1: %Filter{target: self(), ref: 1},
+               filter2: %Filter{target: self(), ref: 2},
                sink: %Sink{target: self(), autodemand: false},
                target: self()
              })
-
-    assert_receive {:filter_pid, filter_pid}
-    assert Process.alive?(filter_pid)
+    [filter_pid1, filter_pid2] =
+    [1, 2]
+    |> Enum.map(&get_filter_pid/1)
 
     assert Pipeline.play(pid) == :ok
     assert_receive :playing
@@ -45,11 +46,63 @@ defmodule Membrane.Integration.ChildRemovalTest do
     send(pid, {:child_msg, :sink, {:make_demand, 10}})
     assert_receive :buffer_in_filter
 
-    send(pid, {:remove_child, :filter})
+    send(pid, {:remove_child, :filter1})
 
     assert_receive :element_shutting_down
-    refute Process.alive?(filter_pid)
+    assert_pid_dead(filter_pid1)
+    assert Process.alive?(filter_pid2)
 
-    assert Pipeline.stop(pid) == :ok
+    stop_pipeline(pid)
   end
+
+  @doc """
+  In this scenario we make filter2 switch between preapre and playing state slowly
+  so that it has to store incoming buffers in PlaybackBuffer. When the filter1 dies,
+  and filter2 tries to actually enter playing it SHOULD NOT have any buffers there yet.
+  """
+  test "When PlaybackBuffer is evaluated there is no buffers from removed element" do
+    assert {:ok, pid} =
+             Pipeline.start_link(ChildRemovalTest.Pipeline, %{
+               source: Source,
+               filter1: %Filter{target: self(), ref: 1},
+               filter2: %Filter{target: self(), playing_delay: 300, ref: 2},
+               sink: %Sink{target: self(), autodemand: false},
+               target: self()
+             })
+    [filter_pid1, filter_pid2] =
+    [1, 2]
+    |> Enum.map(&get_filter_pid/1)
+
+    assert Pipeline.play(pid) == :ok
+    wait_for_state_change()
+    send(pid, {:child_msg, :sink, {:make_demand, 30}})
+    wait_for_buffer()
+
+    send(pid, {:remove_child, :filter1})
+
+    assert_receive :element_shutting_down
+    assert_pid_dead(filter_pid1)
+
+    stop_pipeline(pid)
+  end
+
+  defp stop_pipeline(pid) do
+    assert Pipeline.stop(pid) == :ok
+    assert_receive :pipeline_stopped, 500
+  end
+
+  defp assert_pid_dead(pid) do
+    assert_receive {:DOWN, _, :process, ^pid, :normal}
+  end
+
+  defp wait_for_buffer, do: :timer.sleep(100)
+
+  defp wait_for_state_change, do: :timer.sleep(100)
+
+  defp get_filter_pid(ref) do
+    assert_receive {:filter_pid, ^ref, pid}
+    Process.monitor(pid)
+    pid
+  end
+
 end

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -16,8 +16,8 @@ defmodule Membrane.Integration.ChildRemovalTest do
     assert {:ok, pipeline_pid} =
              Pipeline.start_link(ChildRemovalTest.Pipeline, %{
                source: Testing.Source,
-               filter1: %ChildRemovalTest.Filter{target: self()},
-               filter2: %ChildRemovalTest.Filter{target: self()},
+               filter1: ChildRemovalTest.Filter,
+               filter2: ChildRemovalTest.Filter,
                sink: Testing.Sink,
                target: self()
              })
@@ -28,7 +28,6 @@ defmodule Membrane.Integration.ChildRemovalTest do
 
     ChildRemovalTest.Pipeline.remove_child(pipeline_pid, :filter1)
 
-    assert_receive {:element_shutting_down, ^filter_pid1}
     assert_pid_dead(filter_pid1)
     assert Process.alive?(filter_pid2)
   end
@@ -37,8 +36,8 @@ defmodule Membrane.Integration.ChildRemovalTest do
     assert {:ok, pipeline_pid} =
              Pipeline.start_link(ChildRemovalTest.Pipeline, %{
                source: Testing.Source,
-               filter1: %ChildRemovalTest.Filter{target: self()},
-               filter2: %ChildRemovalTest.Filter{target: self()},
+               filter1: ChildRemovalTest.Filter,
+               filter2: ChildRemovalTest.Filter,
                sink: Testing.Sink,
                target: self()
              })
@@ -53,7 +52,6 @@ defmodule Membrane.Integration.ChildRemovalTest do
 
     ChildRemovalTest.Pipeline.remove_child(pipeline_pid, :filter1)
 
-    assert_receive {:element_shutting_down, ^filter_pid1}
     assert_pid_dead(filter_pid1)
     assert Process.alive?(filter_pid2)
 
@@ -72,11 +70,9 @@ defmodule Membrane.Integration.ChildRemovalTest do
     assert {:ok, pipeline_pid} =
              Pipeline.start_link(ChildRemovalTest.Pipeline, %{
                source: Testing.Source,
-               filter1: %ChildRemovalTest.Filter{target: self(), ref: 1},
+               filter1: ChildRemovalTest.Filter,
                filter2: %ChildRemovalTest.Filter{
-                 target: self(),
-                 playing_delay: prepared_to_playing_delay(),
-                 ref: 2
+                 playing_delay: prepared_to_playing_delay()
                },
                sink: Testing.Sink,
                target: self()
@@ -92,7 +88,6 @@ defmodule Membrane.Integration.ChildRemovalTest do
 
     ChildRemovalTest.Pipeline.remove_child(pipeline_pid, :filter1)
 
-    assert_receive {:element_shutting_down, ^filter_pid1}
     assert_pid_dead(filter_pid1)
     assert_pid_alive(filter_pid2)
 
@@ -118,9 +113,8 @@ defmodule Membrane.Integration.ChildRemovalTest do
              Pipeline.start_link(ChildRemovalTest.Pipeline, %{
                source: %Testing.Source{output: {0, source_buf_gen}},
                extra_source: %Testing.Source{output: {0, extra_source_buf_gen}},
-               filter1: %ChildRemovalTest.Filter{target: self()},
+               filter1: ChildRemovalTest.Filter,
                filter2: %ChildRemovalTest.Filter{
-                 target: self(),
                  playing_delay: prepared_to_playing_delay()
                },
                sink: Testing.Sink,
@@ -137,7 +131,6 @@ defmodule Membrane.Integration.ChildRemovalTest do
 
     ChildRemovalTest.Pipeline.remove_child(pipeline_pid, :filter1)
 
-    assert_receive {:element_shutting_down, ^filter_pid1}
     assert_pid_dead(filter_pid1)
 
     %PlaybackBuffer{q: q} = :sys.get_state(filter_pid2).playback_buffer

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -1,0 +1,55 @@
+defmodule Membrane.Integration.ChildRemovalTest do
+  use ExUnit.Case, async: false
+  use Bunch
+  alias Membrane.Support.ChildRemovalTest
+  alias ChildRemovalTest.Filter
+  alias Membrane.Testing.{Source, Sink}
+  alias Membrane.Pipeline
+
+  test "Element can be removed when pipeline is in stopped state" do
+    assert {:ok, pid} =
+             Pipeline.start_link(ChildRemovalTest.Pipeline, %{
+               source: Source,
+               filter: %Filter{target: self()},
+               sink: %Sink{target: self(), autodemand: false},
+               target: self()
+             })
+
+    assert_receive {:filter_pid, filter_pid}
+    assert Process.alive?(filter_pid)
+
+    send(pid, {:remove_child, :filter})
+    :timer.sleep(1000)
+
+    assert_receive :element_shutting_down
+    refute Process.alive?(filter_pid)
+
+    assert Pipeline.stop(pid) == :ok
+  end
+
+  test "Element can be removed when pipeline is in playing state" do
+    assert {:ok, pid} =
+             Pipeline.start_link(ChildRemovalTest.Pipeline, %{
+               source: Source,
+               filter: %Filter{target: self()},
+               sink: %Sink{target: self(), autodemand: false},
+               target: self()
+             })
+
+    assert_receive {:filter_pid, filter_pid}
+    assert Process.alive?(filter_pid)
+
+    assert Pipeline.play(pid) == :ok
+    assert_receive :playing
+
+    send(pid, {:child_msg, :sink, {:make_demand, 10}})
+    assert_receive :buffer_in_filter
+
+    send(pid, {:remove_child, :filter})
+
+    assert_receive :element_shutting_down
+    refute Process.alive?(filter_pid)
+
+    assert Pipeline.stop(pid) == :ok
+  end
+end

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -14,7 +14,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
                source: Source,
                filter1: %Filter{target: self(), ref: 1},
                filter2: %Filter{target: self(), ref: 2},
-               sink: %Sink{target: self(), autodemand: false},
+               sink: %Sink{autodemand: false},
                target: self()
              })
 
@@ -35,7 +35,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
                source: Source,
                filter1: %Filter{target: self(), ref: 1},
                filter2: %Filter{target: self(), ref: 2},
-               sink: %Sink{target: self(), autodemand: false},
+               sink: %Sink{autodemand: false},
                target: self()
              })
 
@@ -76,7 +76,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
                  playing_delay: prepared_to_playing_delay(),
                  ref: 2
                },
-               sink: %Sink{target: self(), autodemand: false},
+               sink: %Sink{autodemand: false},
                target: self()
              })
 
@@ -116,15 +116,15 @@ defmodule Membrane.Integration.ChildRemovalTest do
 
     assert {:ok, pid} =
              Pipeline.start_link(ChildRemovalTest.Pipeline, %{
-               source: %Source{actions_generator: source_buf_gen},
-               extra_source: %Source{actions_generator: extra_source_buf_gen},
+               source: %Source{output: {0, source_buf_gen}},
+               extra_source: %Source{output: {0, extra_source_buf_gen}},
                filter1: %Filter{target: self(), ref: 1},
                filter2: %Filter{
                  target: self(),
                  playing_delay: prepared_to_playing_delay(),
                  ref: 2
                },
-               sink: %Sink{target: self(), autodemand: false},
+               sink: %Sink{autodemand: false},
                target: self()
              })
 

--- a/test/membrane/integration/child_removal_test.exs
+++ b/test/membrane/integration/child_removal_test.exs
@@ -88,6 +88,7 @@ defmodule Membrane.Integration.ChildRemovalTest do
 
     assert_receive :element_shutting_down
     assert_pid_dead(filter_pid1)
+    assert_pid_alive(filter_pid2)
 
     stop_pipeline(pid)
   end
@@ -99,6 +100,11 @@ defmodule Membrane.Integration.ChildRemovalTest do
 
   defp assert_pid_dead(pid) do
     assert_receive {:DOWN, _, :process, ^pid, :normal}
+  end
+
+  defp assert_pid_alive(pid) do
+    refute_receive {:DOWN, _, :process, ^pid, _}
+    assert Process.alive?(pid)
   end
 
   defp get_filter_pid(ref) do

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -1,5 +1,19 @@
 defmodule Membrane.Support.ChildRemovalTest.Filter do
-  @moduledoc false
+  @moduledoc """
+  Module used in tests for elements removing.
+
+  It allows to:
+  * slow down the moment of switching between :prepared and :playing states.
+  * deactivate demands on `input1` (useful when you want to delete element
+    that is connected to this pad.
+  * not send doubled `%Membrane.Event.StartOfStream{}` element
+    (useful when you have two sources in a pipeline)
+  * send demands and buffers from two input pads to one output pad.
+
+
+  Should be used along with `Membrane.Support.ChildRemovalTest.Pipeline` as they
+  share names (i.e. input_pads: `input1` and `input2`) and exchanged messages' formats.
+  """
 
   alias Membrane.Event.StartOfStream
 

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -37,7 +37,6 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
 
   @impl true
   def handle_init(%{target: t, ref: ref} = opts) do
-    send(t, {:filter_pid, ref, self()})
     {:ok, Map.put(opts, :pads, MapSet.new())}
   end
 

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -21,10 +21,8 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
 
   use Membrane.Filter
 
-  # , availability: :on_request
   def_output_pad :output, caps: :any
 
-  # , availability: :on_request
   def_input_pad :input1, demand_unit: :buffers, caps: :any
 
   def_input_pad :input2, demand_unit: :buffers, caps: :any

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -1,0 +1,41 @@
+defmodule Membrane.Support.ChildRemovalTest.Filter do
+  @moduledoc false
+  use Membrane.Element.Base.Filter
+  alias Membrane.Buffer
+
+  def_output_pad :output, caps: :any, availability: :always
+
+  def_input_pad :input, demand_unit: :buffers, caps: :any, availability: :always
+
+  def_options demand_generator: [
+                type: :function,
+                spec: (pos_integer -> non_neg_integer),
+                default: &__MODULE__.default_demand_generator/1
+              ],
+              target: [type: :pid]
+
+  @impl true
+  def handle_init(%{target: t} = opts) do
+    send(t, {:filter_pid, self()})
+    {:ok, opts}
+  end
+
+  @impl true
+  def handle_demand(:output, size, _, _ctx, state) do
+    {{:ok, demand: {:input, state.demand_generator.(size)}}, state}
+  end
+
+  @impl true
+  def handle_process(:input, %Buffer{payload: payload}, _, %{target: t} = state) do
+    send(t, :buffer_in_filter)
+    {{:ok, buffer: {:output, %Buffer{payload: payload <> <<255>>}}, redemand: :output}, state}
+  end
+
+  @impl true
+  def handle_shutdown(%{target: pid}) do
+    send(pid, :element_shutting_down)
+    :ok
+  end
+
+  def default_demand_generator(demand), do: demand
+end

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -7,8 +7,6 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
   * not send doubled `%Membrane.Event.StartOfStream{}` event
     (useful when you have two sources in a pipeline)
   * send demands and buffers from two input pads to one output pad.
-  * sends to pid specified in options as `target` its pid at init and
-    some other messages informing about playback state changes for example.
 
 
   Should be used along with `Membrane.Support.ChildRemovalTest.Pipeline` as they
@@ -61,7 +59,7 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
 
   @impl true
   def handle_other(:resume_after_wait, _ctx, state) do
-    {{:ok, playback_change: :resume}, state}
+    {{:ok, playback_change: :resume, notify: :playing}, state}
   end
 
   @impl true

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -85,7 +85,7 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
   end
 
   @impl true
-  def handle_process(_pad, buf, _, %{target: t} = state) do
+  def handle_process(_pad, buf, _, state) do
     {{:ok, buffer: {:output, buf}}, state}
   end
 

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -61,7 +61,7 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
   end
 
   def handle_prepared_to_playing(_ctx, %{playing_delay: time} = state) do
-    :timer.send_after(time, self(), :resume_after_wait)
+    Process.send_after(self(), :resume_after_wait, time)
     {{:ok, playback_change: :suspend}, state}
   end
 

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -1,23 +1,38 @@
 defmodule Membrane.Support.ChildRemovalTest.Filter do
   @moduledoc false
   use Membrane.Element.Base.Filter
-  alias Membrane.Buffer
 
-  def_output_pad :output, caps: :any, availability: :always
+  def_output_pad :output, caps: :any#, availability: :on_request
 
-  def_input_pad :input, demand_unit: :buffers, caps: :any, availability: :always
+  def_input_pad :input, demand_unit: :buffers, caps: :any#, availability: :on_request
 
   def_options demand_generator: [
                 type: :function,
                 spec: (pos_integer -> non_neg_integer),
                 default: &__MODULE__.default_demand_generator/1
               ],
-              target: [type: :pid]
+    target: [type: :pid],
+    playing_delay: [type: :integer, default: 0],
+    ref: [type: :any, default: nil]
 
   @impl true
-  def handle_init(%{target: t} = opts) do
-    send(t, {:filter_pid, self()})
+  def handle_init(%{target: t, ref: ref} = opts) do
+    send(t, {:filter_pid, ref, self()})
     {:ok, opts}
+  end
+
+  @impl true
+  def handle_prepared_to_playing(_ctx, %{playing_delay: 0} = state) do
+    {:ok, state}
+  end
+  def handle_prepared_to_playing(_ctx, %{playing_delay: time} = state) do
+    :timer.send_after(time, self(), :resume_after_wait)
+    {{:ok, playback_change: :suspend}, state}
+  end
+
+  @impl true
+  def handle_other(:resume_after_wait, _ctx, state) do
+    {{:ok, playback_change: :resume}, state}
   end
 
   @impl true
@@ -26,9 +41,9 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
   end
 
   @impl true
-  def handle_process(:input, %Buffer{payload: payload}, _, %{target: t} = state) do
+  def handle_process(:input, buf, _, %{target: t} = state) do
     send(t, :buffer_in_filter)
-    {{:ok, buffer: {:output, %Buffer{payload: payload <> <<255>>}}, redemand: :output}, state}
+    {{:ok, buffer: {:output, buf}, redemand: :output}, state}
   end
 
   @impl true

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -9,7 +9,7 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
   def_output_pad :output, caps: :any
 
   # , availability: :on_request
-  def_input_pad :input, demand_unit: :buffers, caps: :any
+  def_input_pad :input1, demand_unit: :buffers, caps: :any
 
   def_input_pad :input2, demand_unit: :buffers, caps: :any
 
@@ -25,7 +25,7 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
               sof_sent?: [type: :boolean, default: false],
               input1_deactivated: [type: :boolean, default: false]
 
-  def deactivate_demands_on_input(pid) do
+  def deactivate_demands_on_input1(pid) do
     send(pid, {:deactivate_input1, self()})
 
     receive do
@@ -70,7 +70,7 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
   end
 
   @impl true
-  def handle_process(:input, buf, _, %{target: t} = state) do
+  def handle_process(:input1, buf, _, %{target: t} = state) do
     send(t, :buffer_in_filter)
     {{:ok, buffer: {:output, buf}}, state}
   end
@@ -102,16 +102,16 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
 
   defp get_demands(%{two_input_pads: true} = state, size),
     do: [
-      demand: {:input, state.demand_generator.(size)},
+      demand: {:input1, state.demand_generator.(size)},
       demand: {:input2, state.demand_generator.(size)}
     ]
 
   defp get_demands(state, size),
-    do: [demand: {:input, state.demand_generator.(size)}]
+    do: [demand: {:input1, state.demand_generator.(size)}]
 
   defp maybe_deactivate_input1(demands, %{input1_deactivated: true}) do
     demands
-    |> Enum.filter(fn {:demand, {i, _}} -> i != :input end)
+    |> Enum.filter(fn {:demand, {i, _}} -> i != :input1 end)
   end
 
   defp maybe_deactivate_input1(demands, _) do

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -30,13 +30,11 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
                 spec: (pos_integer -> non_neg_integer),
                 default: &__MODULE__.default_demand_generator/1
               ],
-              target: [type: :pid],
               playing_delay: [type: :integer, default: 0],
-              ref: [type: :any, default: nil],
               sof_sent?: [type: :boolean, default: false]
 
   @impl true
-  def handle_init(%{target: t, ref: ref} = opts) do
+  def handle_init(opts) do
     {:ok, Map.put(opts, :pads, MapSet.new())}
   end
 
@@ -54,7 +52,7 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
 
   @impl true
   def handle_prepared_to_playing(_ctx, %{playing_delay: 0} = state) do
-    #send(state.target, {:playing, self()})
+    # send(state.target, {:playing, self()})
     {{:ok, notify: :playing}, state}
   end
 
@@ -93,12 +91,6 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
 
   def handle_event(_pad, event, _ctx, state) do
     {{:ok, forward: event}, state}
-  end
-
-  @impl true
-  def handle_shutdown(%{target: pid}) do
-    send(pid, {:element_shutting_down, self()})
-    :ok
   end
 
   def default_demand_generator(demand), do: demand

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -5,7 +5,7 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
   It allows to:
   * slow down the moment of switching between :prepared and :playing states.
   * using dynamic pads
-  * not send doubled `%Membrane.Event.StartOfStream{}` element
+  * not send doubled `%Membrane.Event.StartOfStream{}` event
     (useful when you have two sources in a pipeline)
   * send demands and buffers from two input pads to one output pad.
   * sends to pid specified in options as `target` its pid at init and

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -4,7 +4,6 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
 
   It allows to:
   * slow down the moment of switching between :prepared and :playing states.
-  * using dynamic pads
   * not send doubled `%Membrane.Event.StartOfStream{}` event
     (useful when you have two sources in a pipeline)
   * send demands and buffers from two input pads to one output pad.

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -30,8 +30,7 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
                 spec: (pos_integer -> non_neg_integer),
                 default: &__MODULE__.default_demand_generator/1
               ],
-              playing_delay: [type: :integer, default: 0],
-              sof_sent?: [type: :boolean, default: false]
+              playing_delay: [type: :integer, default: 0]
 
   @impl true
   def handle_init(opts) do
@@ -81,12 +80,12 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
   end
 
   @impl true
-  def handle_event(_pad, %StartOfStream{} = ev, _ctx, %{sof_sent?: false} = state) do
-    {{:ok, forward: ev}, %{state | sof_sent?: true}}
-  end
-
-  def handle_event(_pad, %StartOfStream{}, _ctx, %{sof_sent?: true} = state) do
-    {:ok, state}
+  def handle_event(pad, %StartOfStream{} = ev, ctx, state) do
+    if not ctx.pads[pad].start_of_stream? do
+      {{:ok, forward: ev}, %{state | sof_sent?: true}}
+    else
+      {:ok, state}
+    end
   end
 
   def handle_event(_pad, event, _ctx, state) do

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -51,7 +51,6 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
 
   @impl true
   def handle_prepared_to_playing(_ctx, %{playing_delay: 0} = state) do
-    # send(state.target, {:playing, self()})
     {{:ok, notify: :playing}, state}
   end
 

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -2,18 +2,20 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
   @moduledoc false
   use Membrane.Element.Base.Filter
 
-  def_output_pad :output, caps: :any#, availability: :on_request
+  # , availability: :on_request
+  def_output_pad :output, caps: :any
 
-  def_input_pad :input, demand_unit: :buffers, caps: :any#, availability: :on_request
+  # , availability: :on_request
+  def_input_pad :input, demand_unit: :buffers, caps: :any
 
   def_options demand_generator: [
                 type: :function,
                 spec: (pos_integer -> non_neg_integer),
                 default: &__MODULE__.default_demand_generator/1
               ],
-    target: [type: :pid],
-    playing_delay: [type: :integer, default: 0],
-    ref: [type: :any, default: nil]
+              target: [type: :pid],
+              playing_delay: [type: :integer, default: 0],
+              ref: [type: :any, default: nil]
 
   @impl true
   def handle_init(%{target: t, ref: ref} = opts) do
@@ -25,6 +27,7 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
   def handle_prepared_to_playing(_ctx, %{playing_delay: 0} = state) do
     {:ok, state}
   end
+
   def handle_prepared_to_playing(_ctx, %{playing_delay: time} = state) do
     :timer.send_after(time, self(), :resume_after_wait)
     {{:ok, playback_change: :suspend}, state}

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -17,7 +17,7 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
 
   alias Membrane.Event.StartOfStream
 
-  use Membrane.Element.Base.Filter
+  use Membrane.Filter
 
   # , availability: :on_request
   def_output_pad :output, caps: :any

--- a/test/support/child_removal_test/filter.ex
+++ b/test/support/child_removal_test/filter.ex
@@ -54,8 +54,8 @@ defmodule Membrane.Support.ChildRemovalTest.Filter do
 
   @impl true
   def handle_prepared_to_playing(_ctx, %{playing_delay: 0} = state) do
-    send(state.target, {:playing, self()})
-    {:ok, state}
+    #send(state.target, {:playing, self()})
+    {{:ok, notify: :playing}, state}
   end
 
   def handle_prepared_to_playing(_ctx, %{playing_delay: time} = state) do

--- a/test/support/child_removal_test/pipeline.ex
+++ b/test/support/child_removal_test/pipeline.ex
@@ -1,0 +1,40 @@
+defmodule Membrane.Support.ChildRemovalTest.Pipeline do
+  @moduledoc false
+  use Membrane.Pipeline
+
+  @impl true
+  def handle_init(opts) do
+    children = [
+      source: opts.source,
+      filter: opts.filter,
+      sink: opts.sink
+    ]
+
+    links = %{
+      {:source, :output} => {:filter, :input, buffer: [preferred_size: 50]},
+      {:filter, :output} => {:sink, :input, buffer: [preferred_size: 50]}
+    }
+
+    spec = %Pipeline.Spec{
+      children: children,
+      links: links
+    }
+
+    {{:ok, spec}, %{target: opts.target}}
+  end
+
+  @impl true
+  def handle_other({:child_msg, name, msg}, state) do
+    {{:ok, forward: {name, msg}}, state}
+  end
+
+  def handle_other({:remove_child, name}, state) do
+    {{:ok, remove_child: name}, state}
+  end
+
+  @impl true
+  def handle_prepared_to_playing(%{target: target} = state) do
+    send(target, :playing)
+    {:ok, state}
+  end
+end

--- a/test/support/child_removal_test/pipeline.ex
+++ b/test/support/child_removal_test/pipeline.ex
@@ -1,5 +1,19 @@
 defmodule Membrane.Support.ChildRemovalTest.Pipeline do
-  @moduledoc false
+  @moduledoc """
+  Module used in tests for elements removing.
+
+  This module allows to build two pipelines:
+  * Simple one, with two filters
+      source -- filter1 -- [input1] filter2 -- sink
+  * Pipeline with two sources (if `extra_source` key is provided in opts).
+      source -- filter1 -- [input1] filter2 -- sink
+                                    [input2]
+                                     /
+                    extra_source ___/
+
+  Should be used along with `Membrane.Support.ChildRemovalTest.Pipeline` as they
+  share names (i.e. input_pads: `input1` and `input2`) and exchanged messages' formats.
+  """
   use Membrane.Pipeline
 
   @impl true

--- a/test/support/child_removal_test/pipeline.ex
+++ b/test/support/child_removal_test/pipeline.ex
@@ -6,13 +6,15 @@ defmodule Membrane.Support.ChildRemovalTest.Pipeline do
   def handle_init(opts) do
     children = [
       source: opts.source,
-      filter: opts.filter,
+      filter1: opts.filter1,
+      filter2: opts.filter2,
       sink: opts.sink
     ]
 
     links = %{
-      {:source, :output} => {:filter, :input, buffer: [preferred_size: 50]},
-      {:filter, :output} => {:sink, :input, buffer: [preferred_size: 50]}
+      {:source, :output} => {:filter1, :input, buffer: [preferred_size: 10]},
+      {:filter1, :output} => {:filter2, :input, buffer: [preferred_size: 10]},
+      {:filter2, :output} => {:sink, :input, buffer: [preferred_size: 10]}
     }
 
     spec = %Pipeline.Spec{
@@ -35,6 +37,12 @@ defmodule Membrane.Support.ChildRemovalTest.Pipeline do
   @impl true
   def handle_prepared_to_playing(%{target: target} = state) do
     send(target, :playing)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_prepared_to_stopped(%{target: t} = state) do
+    send(t, :pipeline_stopped)
     {:ok, state}
   end
 end

--- a/test/support/child_removal_test/pipeline.ex
+++ b/test/support/child_removal_test/pipeline.ex
@@ -57,11 +57,6 @@ defmodule Membrane.Support.ChildRemovalTest.Pipeline do
   end
 
   @impl true
-  def handle_prepared_to_playing(state) do
-    {:ok, state}
-  end
-
-  @impl true
   def handle_prepared_to_stopped(%{target: t} = state) do
     send(t, :pipeline_stopped)
     {:ok, state}

--- a/test/support/child_removal_test/pipeline.ex
+++ b/test/support/child_removal_test/pipeline.ex
@@ -61,7 +61,7 @@ defmodule Membrane.Support.ChildRemovalTest.Pipeline do
 
   @impl true
   def handle_prepared_to_playing(%{target: target} = state) do
-    send(target, :playing)
+    send(target, {:playing, self()})
     {:ok, state}
   end
 

--- a/test/support/child_removal_test/pipeline.ex
+++ b/test/support/child_removal_test/pipeline.ex
@@ -64,7 +64,7 @@ defmodule Membrane.Support.ChildRemovalTest.Pipeline do
 
   @impl true
   def handle_prepared_to_playing(%{target: target} = state) do
-    send(target, {:playing, self()})
+    #send(target, {:playing, self()})
     {:ok, state}
   end
 
@@ -72,6 +72,14 @@ defmodule Membrane.Support.ChildRemovalTest.Pipeline do
   def handle_prepared_to_stopped(%{target: t} = state) do
     send(t, :pipeline_stopped)
     {:ok, state}
+  end
+
+  def handle_notification(:playing, element, %{target: target} = state) do
+    send(target, {:playing, element})
+    {:ok, state}
+  end
+  def handle_notification(n, el, st) do
+    {:ok, st}
   end
 
   defp maybe_add_extra_source(children, %{extra_source: source}),

--- a/test/support/child_removal_test/pipeline.ex
+++ b/test/support/child_removal_test/pipeline.ex
@@ -15,8 +15,8 @@ defmodule Membrane.Support.ChildRemovalTest.Pipeline do
 
     links =
       %{
-        {:source, :output} => {:filter1, :input, buffer: [preferred_size: 10]},
-        {:filter1, :output} => {:filter2, :input, buffer: [preferred_size: 10]},
+        {:source, :output} => {:filter1, :input1, buffer: [preferred_size: 10]},
+        {:filter1, :output} => {:filter2, :input1, buffer: [preferred_size: 10]},
         {:filter2, :output} => {:sink, :input, buffer: [preferred_size: 10]}
       }
       |> maybe_add_extra_source_link(opts)

--- a/test/support/child_removal_test/pipeline.ex
+++ b/test/support/child_removal_test/pipeline.ex
@@ -44,7 +44,7 @@ defmodule Membrane.Support.ChildRemovalTest.Pipeline do
       links: links
     }
 
-    {{:ok, spec}, %{target: opts.target}}
+    {{:ok, spec}, %{}}
   end
 
   @impl true
@@ -54,21 +54,6 @@ defmodule Membrane.Support.ChildRemovalTest.Pipeline do
 
   def handle_other({:remove_child, name}, state) do
     {{:ok, remove_child: name}, state}
-  end
-
-  @impl true
-  def handle_prepared_to_stopped(%{target: t} = state) do
-    send(t, :pipeline_stopped)
-    {:ok, state}
-  end
-
-  def handle_notification(:playing, element, %{target: target} = state) do
-    send(target, {:playing, element})
-    {:ok, state}
-  end
-
-  def handle_notification(_, _, state) do
-    {:ok, state}
   end
 
   defp maybe_add_extra_source(children, %{extra_source: source}),

--- a/test/support/child_removal_test/pipeline.ex
+++ b/test/support/child_removal_test/pipeline.ex
@@ -11,6 +11,9 @@ defmodule Membrane.Support.ChildRemovalTest.Pipeline do
                                      /
                     extra_source ___/
 
+  This pipeline also makes children aware of their names. They can reach their
+  name by accessing field `ref` in their opts.
+
   Should be used along with `Membrane.Support.ChildRemovalTest.Pipeline` as they
   share names (i.e. input_pads: `input1` and `input2`) and exchanged messages' formats.
   """
@@ -71,19 +74,10 @@ defmodule Membrane.Support.ChildRemovalTest.Pipeline do
     {:ok, state}
   end
 
-  defp maybe_add_extra_source(children, %{extra_source: source}) do
-    Keyword.update(
-      children,
-      :filter2,
-      nil,
-      fn f -> %{f | two_input_pads: true} end
-    ) ++
-      [extra_source: source]
-  end
+  defp maybe_add_extra_source(children, %{extra_source: source}),
+    do: [{:extra_source, source} | children]
 
-  defp maybe_add_extra_source(children, _) do
-    children
-  end
+  defp maybe_add_extra_source(children, _), do: children
 
   defp maybe_add_extra_source_link(links, %{extra_source: _}) do
     Map.put(links, {:extra_source, :output}, {:filter2, :input2, buffer: [preferred_size: 10]})


### PR DESCRIPTION
This PR tests and corrects pr #169.

TODO:
- [x] Test situation in which playbackbuffer has buffers from different elements.
- [x] get rid of sleeps after rebasing with new test API branch. (There was no point to do this on old test api).
- [x] Remove list args where only one arg is passed (Message)