### PR TITLE
Stream management callbacks

### DIFF
--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -129,7 +129,7 @@ defmodule Membrane.Core.Element.ActionHandler do
 
   defp do_handle_action(
          {:end_of_stream, pad_ref},
-         _cb,
+         _callback,
          _params,
          %State{type: type} = state
        )

--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -98,15 +98,15 @@ defmodule Membrane.Core.Element.ActionHandler do
               :handle_end_of_stream
             ] do
     {action, dir} =
-      case {cb, params} do
-        {:handle_process_list, _} ->
+      case cb do
+        :handle_process_list ->
           {:buffer, :output}
 
-        {:handle_caps, _} ->
+        :handle_caps ->
           {:caps, :output}
 
-        {ev_cb, %{direction: dir}} when ev_cb in [:handle_event, :handle_end_of_stream] ->
-          {:event, Pad.opposite_direction(dir)}
+        ev_cb when ev_cb in [:handle_event, :handle_end_of_stream] ->
+          {:event, Pad.opposite_direction(params.direction)}
       end
 
     pads = state |> PadModel.filter_data(%{direction: dir}) |> Map.keys()

--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -131,7 +131,7 @@ defmodule Membrane.Core.Element.ActionHandler do
          {:end_of_stream, pad_ref},
          _callback,
          _params,
-         %State{type: type} = state
+         %State{type: type, playback: %{state: :playing}} = state
        )
        when is_pad_ref(pad_ref) and type != :sink do
     send_event(pad_ref, %Event.EndOfStream{}, state)

--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -109,11 +109,18 @@ defmodule Membrane.Core.Element.ActionHandler do
           {:event, Pad.opposite_direction(params.direction)}
       end
 
+    result_data =
+      if data == :end_of_stream do
+        %Event.EndOfStream{}
+      else
+        data
+      end
+
     pads = state |> PadModel.filter_data(%{direction: dir}) |> Map.keys()
 
     pads
     |> Bunch.Enum.try_reduce(state, fn pad, st ->
-      do_handle_action({action, {pad, data}}, cb, params, st)
+      do_handle_action({action, {pad, result_data}}, cb, params, st)
     end)
   end
 

--- a/lib/membrane/core/element/event_controller.ex
+++ b/lib/membrane/core/element/event_controller.ex
@@ -7,6 +7,7 @@ defmodule Membrane.Core.Element.EventController do
   alias Core.Element.{ActionHandler, PadModel, State}
   alias Element.{CallbackContext, Pad}
   require CallbackContext.Event
+  require CallbackContext.StreamManagement
   require PadModel
   use Core.Element.Log
   use Bunch
@@ -57,7 +58,7 @@ defmodule Membrane.Core.Element.EventController do
   defp do_exec_handle_event(pad_ref, %event_type{} = event, params, state)
        when event_type in [Event.StartOfStream, Event.EndOfStream] do
     data = PadModel.get_data!(state, pad_ref)
-    context = CallbackContext.Event.from_state(state)
+    context = CallbackContext.StreamManagement.from_state(state)
 
     callback = stream_event_to_callback(event)
     new_params = Map.put(params, :direction, data.direction)

--- a/lib/membrane/core/element/event_controller.ex
+++ b/lib/membrane/core/element/event_controller.ex
@@ -54,8 +54,8 @@ defmodule Membrane.Core.Element.EventController do
 
   @spec do_exec_handle_event(Pad.ref_t(), Event.t(), params :: map, State.t()) ::
           State.stateful_try_t()
-  defp do_exec_handle_event(pad_ref, event, params, state)
-       when event in [%Event.StartOfStream{}, %Event.EndOfStream{}] do
+  defp do_exec_handle_event(pad_ref, %event_type{} = event, params, state)
+       when event_type in [Event.StartOfStream, Event.EndOfStream] do
     data = PadModel.get_data!(state, pad_ref)
     context = CallbackContext.Event.from_state(state)
 

--- a/lib/membrane/core/element/event_controller.ex
+++ b/lib/membrane/core/element/event_controller.ex
@@ -3,12 +3,13 @@ defmodule Membrane.Core.Element.EventController do
   # Module handling events incoming through input pads.
 
   alias Membrane.{Core, Element, Event}
-  alias Core.{CallbackHandler, InputBuffer}
+  alias Core.{CallbackHandler, InputBuffer, Message}
   alias Core.Element.{ActionHandler, PadModel, State}
   alias Element.{CallbackContext, Pad}
   require CallbackContext.Event
   require CallbackContext.StreamManagement
   require PadModel
+  require Message
   use Core.Element.Log
   use Bunch
 
@@ -64,13 +65,17 @@ defmodule Membrane.Core.Element.EventController do
     new_params = Map.put(params, :direction, data.direction)
     args = [pad_ref, context]
 
-    CallbackHandler.exec_and_handle_callback(
-      callback,
-      ActionHandler,
-      new_params,
-      args,
-      state
-    )
+    res =
+      CallbackHandler.exec_and_handle_callback(
+        callback,
+        ActionHandler,
+        new_params,
+        args,
+        state
+      )
+
+    Message.send(state.watcher, callback, [state.name, pad_ref])
+    res
   end
 
   defp do_exec_handle_event(pad_ref, event, params, state) do

--- a/lib/membrane/core/element/event_controller.ex
+++ b/lib/membrane/core/element/event_controller.ex
@@ -74,7 +74,8 @@ defmodule Membrane.Core.Element.EventController do
         state
       )
 
-    Message.send(state.watcher, callback, [state.name, pad_ref])
+    if state.watcher, do: Message.send(state.watcher, callback, [state.name, pad_ref])
+
     res
   end
 

--- a/lib/membrane/core/element/event_controller.ex
+++ b/lib/membrane/core/element/event_controller.ex
@@ -59,11 +59,15 @@ defmodule Membrane.Core.Element.EventController do
     data = PadModel.get_data!(state, pad_ref)
     context = CallbackContext.Event.from_state(state)
 
+    callback = stream_event_to_callback(event)
+    new_params = Map.put(params, :direction, data.direction)
+    args = [pad_ref, context]
+
     CallbackHandler.exec_and_handle_callback(
-      stream_event_to_callback(event),
+      callback,
       ActionHandler,
-      params |> Map.merge(%{direction: data.direction}),
-      [pad_ref, context],
+      new_params,
+      args,
       state
     )
   end
@@ -72,11 +76,14 @@ defmodule Membrane.Core.Element.EventController do
     data = PadModel.get_data!(state, pad_ref)
     context = CallbackContext.Event.from_state(state)
 
+    new_params = Map.put(params, :direction, data.direction)
+    args = [pad_ref, event, context]
+
     CallbackHandler.exec_and_handle_callback(
       :handle_event,
       ActionHandler,
-      params |> Map.merge(%{direction: data.direction}),
-      [pad_ref, event, context],
+      new_params,
+      args,
       state
     )
   end

--- a/lib/membrane/core/element/event_controller.ex
+++ b/lib/membrane/core/element/event_controller.ex
@@ -21,7 +21,7 @@ defmodule Membrane.Core.Element.EventController do
     pad_data = PadModel.get_data!(state, pad_ref)
 
     if not Event.async?(event) && pad_data.mode == :pull && pad_data.direction == :input &&
-         pad_data.input_buf |> InputBuffer.empty?() |> Kernel.not() do
+         buffers_before_event_present?(pad_data) do
       state
       |> PadModel.update_data(pad_ref, :input_buf, &(&1 |> InputBuffer.store(:event, event)))
     else
@@ -98,4 +98,6 @@ defmodule Membrane.Core.Element.EventController do
   end
 
   defp handle_special_event(_pad_ref, _event, state), do: {{:ok, :handle}, state}
+
+  defp buffers_before_event_present?(pad_data), do: not InputBuffer.empty?(pad_data.input_buf)
 end

--- a/lib/membrane/core/element/playback_buffer.ex
+++ b/lib/membrane/core/element/playback_buffer.ex
@@ -132,7 +132,7 @@ defmodule Membrane.Core.Element.PlaybackBuffer do
         if PadModel.get_data!(state, pad_ref, :start_of_stream?) do
           {:ok, state}
         else
-          EventController.handle_event(pad_ref, %Event.StartOfStream{}, state)
+          EventController.handle_start_of_stream(pad_ref, state)
         end
 
       BufferController.handle_buffer(pad_ref, buffers, state)

--- a/lib/membrane/element/action.ex
+++ b/lib/membrane/element/action.ex
@@ -138,7 +138,7 @@ defmodule Membrane.Element.Action do
   forward buffers, `c:Membrane.Element.WithInputPads.handle_caps/4` - caps
   and `c:Membrane.Element.Base.handle_event/4` - events.
   """
-  @type forward_t :: {:forward, Buffer.t() | [Buffer.t()] | Caps.t() | Event.t()}
+  @type forward_t :: {:forward, Buffer.t() | [Buffer.t()] | Caps.t() | Event.t(), :end_of_stream}
 
   @typedoc """
   Suspends/resumes change of playback state.

--- a/lib/membrane/element/action.ex
+++ b/lib/membrane/element/action.ex
@@ -161,7 +161,7 @@ defmodule Membrane.Element.Action do
   Sends EndOfStream event through a pad (output) that triggers
   callback `end_of_stream/3` at the receiver element.
 
-  Forbidden when playback state is stopped.
+  Allowed only when playback is in playing state.
   """
   @type end_of_stream_t :: {:end_of_stream, Pad.ref_t()}
 

--- a/lib/membrane/element/action.ex
+++ b/lib/membrane/element/action.ex
@@ -158,6 +158,14 @@ defmodule Membrane.Element.Action do
   @type playback_change_t :: {:playback_change, :suspend | :resume}
 
   @typedoc """
+  Sends EndOfStream event through a pad (output) that triggers
+  callback `end_of_stream/3` at the receiver element.
+
+  Forbidden when playback state is stopped.
+  """
+  @type end_of_stream_t :: {:end_of_stream, Pad.ref_t()}
+
+  @typedoc """
   Type that defines a single action that may be returned from element callbacks.
 
   Depending on element type, callback, current playback state and other
@@ -173,4 +181,5 @@ defmodule Membrane.Element.Action do
           | redemand_t
           | forward_t
           | playback_change_t
+          | end_of_stream_t
 end

--- a/lib/membrane/element/base.ex
+++ b/lib/membrane/element/base.ex
@@ -191,25 +191,6 @@ defmodule Membrane.Element.Base do
             when reason: :normal | :shutdown | {:shutdown, any}
 
   @doc """
-  Callback invoked when element receives `Membrane.Event.StartOfStream` event.
-  """
-  @callback handle_start_of_stream(
-              pad :: Pad.ref_t(),
-              context :: CallbackContext.StreamManagement.t(),
-              state :: Element.state_t()
-            ) :: callback_return_t
-
-  @doc """
-  Callback invoked when element receives `Membrane.Event.EndOfStream` event
-  emitted when action `end_of_stream` is returned.
-  """
-  @callback handle_end_of_stream(
-              pad :: Pad.ref_t(),
-              context :: CallbackContext.StreamManagement.t(),
-              state :: Element.state_t()
-            ) :: callback_return_t
-
-  @doc """
   Macro defining options that parametrize element.
 
   It automatically generates appropriate struct and documentation.
@@ -264,12 +245,6 @@ defmodule Membrane.Element.Base do
       @impl true
       def handle_shutdown(_reason, _state), do: :ok
 
-      @impl true
-      def handle_start_of_stream(pad, _context, state), do: {:ok, state}
-
-      @impl true
-      def handle_end_of_stream(pad, _context, state), do: {:ok, state}
-
       defoverridable handle_init: 1,
                      handle_stopped_to_prepared: 2,
                      handle_playing_to_prepared: 2,
@@ -279,9 +254,7 @@ defmodule Membrane.Element.Base do
                      handle_pad_added: 3,
                      handle_pad_removed: 3,
                      handle_event: 4,
-                     handle_shutdown: 2,
-                     handle_start_of_stream: 3,
-                     handle_end_of_stream: 3
+                     handle_shutdown: 2
     end
   end
 end

--- a/lib/membrane/element/base.ex
+++ b/lib/membrane/element/base.ex
@@ -195,7 +195,7 @@ defmodule Membrane.Element.Base do
   """
   @callback handle_start_of_stream(
               pad :: Pad.ref_t(),
-              context :: CallbackContext.Event.t(),
+              context :: CallbackContext.StreamManagement.t(),
               state :: Element.state_t()
             ) :: callback_return_t
 
@@ -205,7 +205,7 @@ defmodule Membrane.Element.Base do
   """
   @callback handle_end_of_stream(
               pad :: Pad.ref_t(),
-              context :: CallbackContext.Event.t(),
+              context :: CallbackContext.StreamManagement.t(),
               state :: Element.state_t()
             ) :: callback_return_t
 

--- a/lib/membrane/element/base.ex
+++ b/lib/membrane/element/base.ex
@@ -190,6 +190,16 @@ defmodule Membrane.Element.Base do
   @callback handle_shutdown(reason, state :: Element.state_t()) :: :ok
             when reason: :normal | :shutdown | {:shutdown, any}
 
+  # TODO docs
+  # TODO do we need to pass event and context here?
+  @doc """
+  """
+  @callback handle_start_of_stream(
+              pad :: Pad.ref_t(),
+              context :: CallbackContext.Event.t(),
+              state :: Element.state_t()
+            ) :: callback_return_t
+
   @doc """
   Macro defining options that parametrize element.
 
@@ -240,10 +250,6 @@ defmodule Membrane.Element.Base do
       def handle_pad_removed(_pad, _context, state), do: {:ok, state}
 
       @impl true
-      def handle_event(pad, %Event.StartOfStream{}, _context, state),
-        do: {{:ok, notify: {:start_of_stream, pad}}, state}
-
-      @impl true
       def handle_event(pad, %Event.EndOfStream{}, _context, state),
         do: {{:ok, notify: {:end_of_stream, pad}}, state}
 
@@ -251,6 +257,11 @@ defmodule Membrane.Element.Base do
 
       @impl true
       def handle_shutdown(_reason, _state), do: :ok
+
+      @impl true
+      def handle_start_of_stream(pad, _context, state),
+        do: {{:ok, notify: {:start_of_stream, pad}}, state}
+
 
       defoverridable handle_init: 1,
                      handle_stopped_to_prepared: 2,
@@ -261,7 +272,8 @@ defmodule Membrane.Element.Base do
                      handle_pad_added: 3,
                      handle_pad_removed: 3,
                      handle_event: 4,
-                     handle_shutdown: 2
+                     handle_shutdown: 2,
+                     handle_start_of_stream: 3
     end
   end
 end

--- a/lib/membrane/element/base.ex
+++ b/lib/membrane/element/base.ex
@@ -265,12 +265,10 @@ defmodule Membrane.Element.Base do
       def handle_shutdown(_reason, _state), do: :ok
 
       @impl true
-      def handle_start_of_stream(pad, _context, state),
-        do: {{:ok, notify: {:start_of_stream, pad}}, state}
+      def handle_start_of_stream(pad, _context, state), do: {:ok, state}
 
       @impl true
-      def handle_end_of_stream(pad, _context, state),
-        do: {{:ok, notify: {:end_of_stream, pad}}, state}
+      def handle_end_of_stream(pad, _context, state), do: {:ok, state}
 
       defoverridable handle_init: 1,
                      handle_stopped_to_prepared: 2,

--- a/lib/membrane/element/base.ex
+++ b/lib/membrane/element/base.ex
@@ -200,6 +200,16 @@ defmodule Membrane.Element.Base do
               state :: Element.state_t()
             ) :: callback_return_t
 
+  # TODO docs
+  # TODO do we need to pass event and context here?
+  @doc """
+  """
+  @callback handle_end_of_stream(
+              pad :: Pad.ref_t(),
+              context :: CallbackContext.Event.t(),
+              state :: Element.state_t()
+            ) :: callback_return_t
+
   @doc """
   Macro defining options that parametrize element.
 
@@ -250,9 +260,6 @@ defmodule Membrane.Element.Base do
       def handle_pad_removed(_pad, _context, state), do: {:ok, state}
 
       @impl true
-      def handle_event(pad, %Event.EndOfStream{}, _context, state),
-        do: {{:ok, notify: {:end_of_stream, pad}}, state}
-
       def handle_event(_pad, _event, _context, state), do: {:ok, state}
 
       @impl true
@@ -262,6 +269,9 @@ defmodule Membrane.Element.Base do
       def handle_start_of_stream(pad, _context, state),
         do: {{:ok, notify: {:start_of_stream, pad}}, state}
 
+      @impl true
+      def handle_end_of_stream(pad, _context, state),
+        do: {{:ok, notify: {:end_of_stream, pad}}, state}
 
       defoverridable handle_init: 1,
                      handle_stopped_to_prepared: 2,
@@ -273,7 +283,8 @@ defmodule Membrane.Element.Base do
                      handle_pad_removed: 3,
                      handle_event: 4,
                      handle_shutdown: 2,
-                     handle_start_of_stream: 3
+                     handle_start_of_stream: 3,
+                     handle_end_of_stream: 3
     end
   end
 end

--- a/lib/membrane/element/base.ex
+++ b/lib/membrane/element/base.ex
@@ -190,9 +190,8 @@ defmodule Membrane.Element.Base do
   @callback handle_shutdown(reason, state :: Element.state_t()) :: :ok
             when reason: :normal | :shutdown | {:shutdown, any}
 
-  # TODO docs
-  # TODO do we need to pass event and context here?
   @doc """
+  Callback invoked when element receives `Membrane.Event.StartOfStream` event.
   """
   @callback handle_start_of_stream(
               pad :: Pad.ref_t(),
@@ -200,9 +199,9 @@ defmodule Membrane.Element.Base do
               state :: Element.state_t()
             ) :: callback_return_t
 
-  # TODO docs
-  # TODO do we need to pass event and context here?
   @doc """
+  Callback invoked when element receives `Membrane.Event.EndOfStream` event
+  emitted when action `end_of_stream` is returned.
   """
   @callback handle_end_of_stream(
               pad :: Pad.ref_t(),

--- a/lib/membrane/element/callback_context/stream_management.ex
+++ b/lib/membrane/element/callback_context/stream_management.ex
@@ -1,0 +1,7 @@
+defmodule Membrane.Element.CallbackContext.StreamManagement do
+  @moduledoc """
+  Structure representing a context that is passed to the element
+  when handling start and end of stream events.
+  """
+  use Membrane.Element.CallbackContext
+end

--- a/lib/membrane/element/pad.ex
+++ b/lib/membrane/element/pad.ex
@@ -143,4 +143,8 @@ defmodule Membrane.Element.Pad do
   """
   def name_by_ref({:dynamic, name, _id}) when is_pad_name(name), do: name
   def name_by_ref(ref) when is_pad_name(ref), do: ref
+
+  @spec opposite_direction(direction_t()) :: direction_t()
+  def opposite_direction(:input), do: :output
+  def opposite_direction(:output), do: :input
 end

--- a/lib/membrane/element/with_input_pads.ex
+++ b/lib/membrane/element/with_input_pads.ex
@@ -26,6 +26,25 @@ defmodule Membrane.Element.WithInputPads do
             ) :: CommonBehaviour.callback_return_t()
 
   @doc """
+  Callback invoked when element receives `Membrane.Event.StartOfStream` event.
+  """
+  @callback handle_start_of_stream(
+              pad :: Pad.ref_t(),
+              context :: CallbackContext.StreamManagement.t(),
+              state :: Element.state_t()
+            ) :: CommonBehaviour.callback_return_t()
+
+  @doc """
+  Callback invoked when element receives `Membrane.Event.EndOfStream` event
+  emitted when action `end_of_stream` is returned.
+  """
+  @callback handle_end_of_stream(
+              pad :: Pad.ref_t(),
+              context :: CallbackContext.StreamManagement.t(),
+              state :: Element.state_t()
+            ) :: CommonBehaviour.callback_return_t()
+
+  @doc """
   Macro that defines multiple input pads for the element.
 
   Deprecated in favor of `def_input_pad/2`
@@ -49,7 +68,15 @@ defmodule Membrane.Element.WithInputPads do
       @impl true
       def handle_caps(_pad, _caps, _context, state), do: {:ok, state}
 
-      defoverridable handle_caps: 4
+      @impl true
+      def handle_start_of_stream(pad, _context, state), do: {:ok, state}
+
+      @impl true
+      def handle_end_of_stream(pad, _context, state), do: {:ok, state}
+
+      defoverridable handle_caps: 4,
+                     handle_start_of_stream: 3,
+                     handle_end_of_stream: 3
     end
   end
 end

--- a/lib/membrane/filter.ex
+++ b/lib/membrane/filter.ex
@@ -82,7 +82,7 @@ defmodule Membrane.Filter do
       end
 
       @impl true
-      def handle_end_of_stream(pad, _context, state), do: {{:ok, forward: %EndOfStream{}}, state}
+      def handle_end_of_stream(pad, _context, state), do: {{:ok, forward: :end_of_stream}, state}
 
       defoverridable handle_caps: 4,
                      handle_event: 4,

--- a/lib/membrane/filter.ex
+++ b/lib/membrane/filter.ex
@@ -53,6 +53,9 @@ defmodule Membrane.Filter do
       use Membrane.Element.Base
       use Membrane.Element.WithOutputPads
       use Membrane.Element.WithInputPads
+
+      alias Membrane.Event.EndOfStream
+
       @behaviour unquote(__MODULE__)
 
       @impl true
@@ -78,11 +81,15 @@ defmodule Membrane.Filter do
         {{:ok, split: {:handle_process, args_list}}, state}
       end
 
+      @impl true
+      def handle_end_of_stream(pad, _context, state), do: {{:ok, forward: %EndOfStream{}}, state}
+
       defoverridable handle_caps: 4,
                      handle_event: 4,
                      handle_demand: 5,
                      handle_process_list: 4,
-                     handle_process: 4
+                     handle_process: 4,
+                     handle_end_of_stream: 3
     end
   end
 end

--- a/lib/membrane/pipeline.ex
+++ b/lib/membrane/pipeline.ex
@@ -118,11 +118,17 @@ defmodule Membrane.Pipeline do
   """
   @callback handle_other(message :: any, state :: State.internal_state_t()) :: callback_return_t
 
+  @doc """
+  Callback invoked when pipeline's element receives start_of_stream event.
+  """
   @callback handle_element_start_of_stream(
               {Element.name_t(), Pad.t()},
               state :: State.internal_state_t()
             ) :: callback_return_t
 
+  @doc """
+  Callback invoked when pipeline's element receives end_of_stream event.
+  """
   @callback handle_element_end_of_stream(
               {Element.name_t(), Pad.t()},
               state :: State.internal_state_t()

--- a/lib/membrane/testing/assertions.ex
+++ b/lib/membrane/testing/assertions.ex
@@ -347,6 +347,19 @@ defmodule Membrane.Testing.Assertions do
     )
   end
 
+  def assert_handle_element_end_of_stream(
+        pipeline,
+        element_name,
+        pad \\ :input,
+        timeout \\ @default_timeout
+      ) do
+    assert_receive_from_pipeline(
+      pipeline,
+      {:handle_element_end_of_stream, {element_name, pad}},
+      timeout
+    )
+  end
+
   @doc """
   Asserts that `Membrane.Testing.Pipeline` received or is going to receive
   `:start_of_stream` from the element with element `element_name` within the

--- a/lib/membrane/testing/assertions.ex
+++ b/lib/membrane/testing/assertions.ex
@@ -334,12 +334,19 @@ defmodule Membrane.Testing.Assertions do
     end
   end
 
-  def assert_handle_element_start_of_stream(
-        pipeline,
-        element_name,
-        pad \\ :input,
-        timeout \\ @default_timeout
-      ) do
+  @doc """
+  Asserts that `Membrane.Testing.Pipeline` received or is going to receive
+  start_of_stream event from the element with element `element_name` within the
+  `timeout` period specified in milliseconds.
+
+      assert_start_of_stream(pipeline, :an_element)
+  """
+  defmacro assert_start_of_stream(
+             pipeline,
+             element_name,
+             pad \\ :input,
+             timeout \\ @default_timeout
+           ) do
     assert_receive_from_pipeline(
       pipeline,
       {:handle_element_start_of_stream, {element_name, pad}},
@@ -347,38 +354,23 @@ defmodule Membrane.Testing.Assertions do
     )
   end
 
-  def assert_handle_element_end_of_stream(
-        pipeline,
-        element_name,
-        pad \\ :input,
-        timeout \\ @default_timeout
-      ) do
+  @doc """
+  Asserts that `Membrane.Testing.Pipeline` received or is going to receive
+  end_of_stream event from the element with name `element_name` within the `timeout`
+  period specified in milliseconds.
+
+      assert_end_of_stream(pipeline, :an_element)
+  """
+  defmacro assert_end_of_stream(
+             pipeline,
+             element_name,
+             pad \\ :input,
+             timeout \\ @default_timeout
+           ) do
     assert_receive_from_pipeline(
       pipeline,
       {:handle_element_end_of_stream, {element_name, pad}},
       timeout
     )
-  end
-
-  @doc """
-  Asserts that `Membrane.Testing.Pipeline` received or is going to receive
-  `:start_of_stream` from the element with element `element_name` within the
-  `timeout` period specified in milliseconds.
-
-      assert_start_of_stream(pipeline, :an_element)
-  """
-  def assert_start_of_stream(pipeline, element_name, pad \\ :input, timeout \\ @default_timeout) do
-    assert_pipeline_notified(pipeline, element_name, {:start_of_stream, ^pad}, timeout)
-  end
-
-  @doc """
-  Asserts that `Membrane.Testing.Pipeline` received or is going to receive
-  `:end_of_stream` from the element with name `element_name` within the `timeout`
-  period specified in milliseconds.
-
-      assert_end_of_stream(pipeline, :an_element)
-  """
-  def assert_end_of_stream(pipeline, element_name, pad \\ :input, timeout \\ @default_timeout) do
-    assert_pipeline_notified(pipeline, element_name, {:end_of_stream, ^pad}, timeout)
   end
 end

--- a/lib/membrane/testing/assertions.ex
+++ b/lib/membrane/testing/assertions.ex
@@ -334,6 +334,19 @@ defmodule Membrane.Testing.Assertions do
     end
   end
 
+  def assert_handle_element_start_of_stream(
+        pipeline,
+        element_name,
+        pad \\ :input,
+        timeout \\ @default_timeout
+      ) do
+    assert_receive_from_pipeline(
+      pipeline,
+      {:handle_element_start_of_stream, {element_name, pad}},
+      timeout
+    )
+  end
+
   @doc """
   Asserts that `Membrane.Testing.Pipeline` received or is going to receive
   `:start_of_stream` from the element with element `element_name` within the

--- a/lib/membrane/testing/pipeline.ex
+++ b/lib/membrane/testing/pipeline.ex
@@ -318,6 +318,11 @@ defmodule Membrane.Testing.Pipeline do
 
   defp default_options(default), do: default
 
+  @impl true
+  def handle_element_end_of_stream({_element, _pad} = arg, state) do
+    notify_test_process({:handle_element_end_of_stream, arg}, state)
+  end
+
   defp eval(custom_function, custom_args, function, state)
 
   defp eval(_, _, function, %State{module: nil}),

--- a/lib/membrane/testing/pipeline.ex
+++ b/lib/membrane/testing/pipeline.ex
@@ -308,6 +308,11 @@ defmodule Membrane.Testing.Pipeline do
         state
       )
 
+  @impl true
+  def handle_element_start_of_stream({_element, _pad} = arg, state) do
+    notify_test_process({:handle_element_start_of_stream, arg}, state)
+  end
+
   defp default_options(%Options{test_process: nil} = options),
     do: %Options{options | test_process: self()}
 

--- a/lib/membrane/testing/source.ex
+++ b/lib/membrane/testing/source.ex
@@ -95,7 +95,7 @@ defmodule Membrane.Testing.Source do
 
     actions =
       case output do
-        [] -> [buffer: {:output, buffers}, event: {:output, %EndOfStream{}}]
+        [] -> [buffer: {:output, buffers}, end_of_stream: :output]
         _ -> [buffer: {:output, buffers}]
       end
 

--- a/lib/membrane/testing/source.ex
+++ b/lib/membrane/testing/source.ex
@@ -26,7 +26,6 @@ defmodule Membrane.Testing.Source do
   use Membrane.Source
   alias Membrane.Buffer
   alias Membrane.Element.Action
-  alias Membrane.Event.EndOfStream
 
   @type generator ::
           (state :: any(), buffers_cnt :: pos_integer -> {[Action.t()], state :: any()})

--- a/spec/membrane/core/element/pad_controller_spec.exs
+++ b/spec/membrane/core/element/pad_controller_spec.exs
@@ -3,13 +3,15 @@ defmodule Membrane.Core.Element.PadControllerSpec do
   alias Membrane.Support.Element.{DynamicFilter, TrivialFilter}
   alias Membrane.Core.Element.{PadModel, PadSpecHandler, State}
   alias Membrane.Event.EndOfStream
+  alias Membrane.Core.Playbackable
 
   describe ".link_pad/7" do
     let :module, do: TrivialFilter
     let :name, do: :element_name
 
     let! :state do
-      State.new(module(), name()) |> PadSpecHandler.init_pads()
+      State.new(module(), name())
+      |> PadSpecHandler.init_pads()
     end
 
     context "when pad is present in the element" do
@@ -121,6 +123,7 @@ defmodule Membrane.Core.Element.PadControllerSpec do
     let! :state do
       {pad_info, state} =
         State.new(module(), name())
+        |> Playbackable.update_playback(&%{&1 | state: :playing})
         |> PadSpecHandler.init_pads()
         |> Bunch.Access.get_and_update_in(
           [:pads, :info],

--- a/spec/membrane/core/element/pad_controller_spec.exs
+++ b/spec/membrane/core/element/pad_controller_spec.exs
@@ -171,7 +171,7 @@ defmodule Membrane.Core.Element.PadControllerSpec do
           )
 
         expect(result) |> to(eq :ok)
-        expect(module() |> to(accepted(:handle_event)))
+        expect(module() |> to(accepted(:handle_end_of_stream)))
         expect(state.pads.data[pad_ref()]) |> to(be_nil())
       end
     end
@@ -197,7 +197,7 @@ defmodule Membrane.Core.Element.PadControllerSpec do
           )
 
         expect(result) |> to(eq :ok)
-        expect(module() |> to(accepted(:handle_event)))
+        expect(module() |> to(accepted(:handle_end_of_stream)))
         expect(module() |> to(accepted(:handle_pad_removed)))
         expect(state.pads.data[pad_ref()]) |> to(be_nil())
       end

--- a/test/membrane/core/element/pad_controller_test.exs
+++ b/test/membrane/core/element/pad_controller_test.exs
@@ -119,7 +119,7 @@ defmodule Membrane.Core.Element.PadControllerTest do
       state = prepare_static_state(TrivialSink, :input)
       assert state.pads.data |> Map.has_key?(:input)
       assert {:ok, new_state} = @module.handle_unlink(:input, state)
-      assert_received Message.new(:notification, [:element, {:end_of_stream, :input}])
+      assert_received Message.new(:handle_end_of_stream, [:element, :input])
       refute new_state.pads.data |> Map.has_key?(:input)
     end
 

--- a/test/membrane/core/element/pad_controller_test.exs
+++ b/test/membrane/core/element/pad_controller_test.exs
@@ -5,7 +5,6 @@ defmodule Membrane.Core.Element.PadControllerTest do
   alias Membrane.Core.Message
   alias Membrane.Element.Pad
   alias Membrane.ElementLinkError
-  alias Membrane.Event.EndOfStream
   require Message
 
   @module Membrane.Core.Element.PadController
@@ -129,7 +128,7 @@ defmodule Membrane.Core.Element.PadControllerTest do
       state = prepare_dynamic_state(DynamicFilter, :input, pad_ref)
       assert state.pads.data |> Map.has_key?(pad_ref)
       assert {:ok, new_state} = @module.handle_unlink(pad_ref, state)
-      assert new_state.internal_state.last_event == {pad_ref, %EndOfStream{}}
+      assert new_state.internal_state[:last_event] == nil
       assert new_state.internal_state.last_pad_removed == pad_ref
       refute new_state.pads.data |> Map.has_key?(pad_ref)
     end

--- a/test/membrane/element/element_test.exs
+++ b/test/membrane/element/element_test.exs
@@ -109,5 +109,11 @@ defmodule Membrane.Element.ElementTest do
 
       TestFilter.refute_callback_called(:handle_event)
     end
+
+    test "causes handle_element_end_of_stream/3 to be called in pipeline", %{pipeline: pipeline} do
+      Pipeline.play(pipeline)
+
+      assert_handle_element_end_of_stream(pipeline, :filter)
+    end
   end
 end

--- a/test/membrane/element/element_test.exs
+++ b/test/membrane/element/element_test.exs
@@ -74,6 +74,12 @@ defmodule Membrane.Element.ElementTest do
 
       TestFilter.refute_callback_called(:handle_event)
     end
+
+    test "causes handle_element_start_of_stream/3 to be called in pipeline", %{pipeline: pipeline} do
+      Pipeline.play(pipeline)
+
+      assert_handle_element_start_of_stream(pipeline, :filter)
+    end
   end
 
   describe "End of stream" do

--- a/test/membrane/element/element_test.exs
+++ b/test/membrane/element/element_test.exs
@@ -78,7 +78,7 @@ defmodule Membrane.Element.ElementTest do
     test "causes handle_element_start_of_stream/3 to be called in pipeline", %{pipeline: pipeline} do
       Pipeline.play(pipeline)
 
-      assert_handle_element_start_of_stream(pipeline, :filter)
+      assert_start_of_stream(pipeline, :filter)
     end
   end
 
@@ -113,7 +113,7 @@ defmodule Membrane.Element.ElementTest do
     test "causes handle_element_end_of_stream/3 to be called in pipeline", %{pipeline: pipeline} do
       Pipeline.play(pipeline)
 
-      assert_handle_element_end_of_stream(pipeline, :filter)
+      assert_end_of_stream(pipeline, :filter)
     end
   end
 end

--- a/test/membrane/element/element_test.exs
+++ b/test/membrane/element/element_test.exs
@@ -1,0 +1,85 @@
+defmodule Membrane.Element.ElementTest do
+  use ExUnit.Case, async: true
+
+  import Membrane.Testing.Assertions
+
+  alias Membrane.Pipeline
+  alias Membrane.Testing
+  alias Membrane.Event.{StartOfStream, EndOfStream}
+
+  defmodule TestFilter do
+    use Membrane.Filter
+
+    def_input_pad :input, demand_unit: :buffers, caps: :any
+
+    def_output_pad :output, caps: :any
+
+    def_options target: [type: :pid]
+
+    def assert_callback_called(name), do: assert_receive({:callback_called, ^name})
+
+    def refute_callback_called(name), do: refute_receive({:callback_called, ^name})
+
+    @impl true
+    def handle_init(opts), do: {:ok, opts}
+
+    @impl true
+    def handle_start_of_stream(_pad, _context, state) do
+      send(state.target, {:callback_called, :handle_start_of_stream})
+      {:ok, state}
+    end
+
+    @impl true
+    def handle_event(_, _, _, state) do
+      send(state.target, {:callback_called, :handle_event})
+      {:ok, state}
+    end
+
+    @impl true
+    def handle_demand(_, _, _, _ctx, state) do
+      {:ok, state}
+    end
+  end
+
+  setup do
+    {:ok, pipeline} =
+      Testing.Pipeline.start_link(%Testing.Pipeline.Options{
+        elements: [
+          source: Testing.Source,
+          filter: %TestFilter{target: self()},
+          sink: Testing.Sink
+        ]
+      })
+
+    [pipeline: pipeline]
+  end
+
+  describe "Start of stream" do
+    setup do
+      {:ok, pipeline} =
+        Testing.Pipeline.start_link(%Testing.Pipeline.Options{
+          elements: [
+            source: Testing.Source,
+            filter: %TestFilter{target: self()},
+            sink: Testing.Sink
+          ]
+        })
+
+      [pipeline: pipeline]
+    end
+
+    test "causes handle_start_of_stream/3 to be called", %{pipeline: pipeline} do
+      Pipeline.play(pipeline)
+      assert_pipeline_playback_changed(pipeline, _, :playing)
+
+      TestFilter.assert_callback_called(:handle_start_of_stream)
+    end
+
+    test "does not trigger calling callback handle_event/3", %{pipeline: pipeline} do
+      Pipeline.play(pipeline)
+      assert_pipeline_playback_changed(pipeline, _, :playing)
+
+      TestFilter.refute_callback_called(:handle_event)
+    end
+  end
+end

--- a/test/membrane/element/element_test.exs
+++ b/test/membrane/element/element_test.exs
@@ -5,7 +5,6 @@ defmodule Membrane.Element.ElementTest do
 
   alias Membrane.Pipeline
   alias Membrane.Testing
-  alias Membrane.Event.{StartOfStream, EndOfStream}
 
   defmodule TestFilter do
     use Membrane.Filter
@@ -30,7 +29,7 @@ defmodule Membrane.Element.ElementTest do
     end
 
     @impl true
-    def handle_event(_, _, _, state) do
+    def handle_event(_, _ = event, _, state) do
       send(state.target, {:callback_called, :handle_event})
       {:ok, state}
     end

--- a/test/membrane/element/element_test.exs
+++ b/test/membrane/element/element_test.exs
@@ -3,7 +3,6 @@ defmodule Membrane.Element.ElementTest do
 
   import Membrane.Testing.Assertions
 
-  alias Membrane.Pipeline
   alias Membrane.Testing
 
   defmodule TestFilter do
@@ -62,21 +61,21 @@ defmodule Membrane.Element.ElementTest do
     end
 
     test "causes handle_start_of_stream/3 to be called", %{pipeline: pipeline} do
-      Pipeline.play(pipeline)
+      Testing.Pipeline.play(pipeline)
       assert_pipeline_playback_changed(pipeline, _, :playing)
 
       TestFilter.assert_callback_called(:handle_start_of_stream)
     end
 
     test "does not trigger calling callback handle_event/3", %{pipeline: pipeline} do
-      Pipeline.play(pipeline)
+      Testing.Pipeline.play(pipeline)
       assert_pipeline_playback_changed(pipeline, _, :playing)
 
       TestFilter.refute_callback_called(:handle_event)
     end
 
     test "causes handle_element_start_of_stream/3 to be called in pipeline", %{pipeline: pipeline} do
-      Pipeline.play(pipeline)
+      Testing.Pipeline.play(pipeline)
 
       assert_start_of_stream(pipeline, :filter)
     end
@@ -97,21 +96,21 @@ defmodule Membrane.Element.ElementTest do
     end
 
     test "causes handle_end_of_stream/3 to be called", %{pipeline: pipeline} do
-      Pipeline.play(pipeline)
+      Testing.Pipeline.play(pipeline)
       assert_pipeline_playback_changed(pipeline, _, :playing)
 
       TestFilter.assert_callback_called(:handle_end_of_stream)
     end
 
     test "does not trigger calling callback handle_event/3", %{pipeline: pipeline} do
-      Pipeline.play(pipeline)
+      Testing.Pipeline.play(pipeline)
       assert_pipeline_playback_changed(pipeline, _, :playing)
 
       TestFilter.refute_callback_called(:handle_event)
     end
 
     test "causes handle_element_end_of_stream/3 to be called in pipeline", %{pipeline: pipeline} do
-      Pipeline.play(pipeline)
+      Testing.Pipeline.play(pipeline)
 
       assert_end_of_stream(pipeline, :filter)
     end

--- a/test/membrane/testing/pipeline_assertions_test.exs
+++ b/test/membrane/testing/pipeline_assertions_test.exs
@@ -242,7 +242,7 @@ defmodule Membrane.Testing.PipelineAssertionsTest do
 
   describe "assert_start_of_stream" do
     test "does not flunk when :start_of_stream is handled by pipeline", %{state: state} do
-      Pipeline.handle_notification({:start_of_stream, :input}, :sink, state)
+      Pipeline.handle_element_start_of_stream({:sink, :input}, state)
       assert_start_of_stream(self(), :sink)
     end
 
@@ -255,7 +255,7 @@ defmodule Membrane.Testing.PipelineAssertionsTest do
 
   describe "assert_end_of_stream" do
     test "does not flunk when :end_of_stream is handled by pipeline", %{state: state} do
-      Pipeline.handle_notification({:end_of_stream, :input}, :sink, state)
+      Pipeline.handle_element_end_of_stream({:sink, :input}, state)
       assert_end_of_stream(self(), :sink)
     end
 

--- a/test/membrane/testing/source_test.exs
+++ b/test/membrane/testing/source_test.exs
@@ -37,11 +37,10 @@ defmodule Membrane.Testing.SourceTest do
 
       assert [
                {:buffer, {:output, [buffer]}},
-               {:event, {:output, event}}
+               {:end_of_stream, :output}
              ] = actions
 
       assert %Buffer{payload: payload} == buffer
-      assert event = %Membrane.Event.EndOfStream{}
     end
   end
 end


### PR DESCRIPTION
TODO:
- [x] Create action `end_of_stream`
- [ ] Should watcher be informed about start of stream synchronously or asynchronously?