### PR TITLE
Handle_shutdown callback

### DIFF
--- a/lib/membrane/core/element/lifecycle_controller.ex
+++ b/lib/membrane/core/element/lifecycle_controller.ex
@@ -72,7 +72,7 @@ defmodule Membrane.Core.Element.LifecycleController do
     end
 
     %State{module: module, internal_state: internal_state} = state
-    :ok = module.handle_shutdown(internal_state)
+    :ok = module.handle_shutdown(reason, internal_state)
     {:ok, state}
   end
 

--- a/lib/membrane/element.ex
+++ b/lib/membrane/element.ex
@@ -127,7 +127,7 @@ defmodule Membrane.Element do
   It will wait for reply for amount of time passed as second argument
   (in milliseconds).
 
-  Will trigger calling `c:Membrane.Element.Base.handle_shutdown/1`
+  Will trigger calling the `c:Membrane.Element.Base.handle_shutdown/2`
   callback.
   """
   @spec shutdown(pid, timeout) :: :ok

--- a/lib/membrane/element/action.ex
+++ b/lib/membrane/element/action.ex
@@ -6,7 +6,7 @@ defmodule Membrane.Element.Action do
   Returning actions is a way of element interaction with
   other elements and parts of framework. Each action may be returned by any
   callback (except for `c:Membrane.Element.Base.handle_init/1`
-  and `c:Membrane.Element.Base.handle_shutdown/1`, as they
+  and `c:Membrane.Element.Base.handle_shutdown/2`, as they
   do not return any actions) unless explicitly stated otherwise.
   """
 

--- a/lib/membrane/element/base.ex
+++ b/lib/membrane/element/base.ex
@@ -185,9 +185,10 @@ defmodule Membrane.Element.Base do
 
   @doc """
   Callback invoked when element is shutting down just before process is exiting.
-  Internally called in `c:GenServer.termintate/2` callback.
+  Internally called in `c:GenServer.terminate/2` callback.
   """
-  @callback handle_shutdown(state :: Element.state_t()) :: :ok
+  @callback handle_shutdown(reason, state :: Element.state_t()) :: :ok
+            when reason: :normal | :shutdown | {:shutdown, any}
 
   @doc """
   Macro defining options that parametrize element.
@@ -249,7 +250,7 @@ defmodule Membrane.Element.Base do
       def handle_event(_pad, _event, _context, state), do: {:ok, state}
 
       @impl true
-      def handle_shutdown(_state), do: :ok
+      def handle_shutdown(_reason, _state), do: :ok
 
       defoverridable handle_init: 1,
                      handle_stopped_to_prepared: 2,
@@ -260,7 +261,7 @@ defmodule Membrane.Element.Base do
                      handle_pad_added: 3,
                      handle_pad_removed: 3,
                      handle_event: 4,
-                     handle_shutdown: 1
+                     handle_shutdown: 2
     end
   end
 end


### PR DESCRIPTION
# handle_shutdown

Added `handle_shutdown` (executed on `terminate`) callback to Pipeline.

Updated `handle_shutdown` callback in Element.