### PR TITLE
Integration tests for Clocks and Timers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,6 @@ jobs:
       - run: mix deps.get
       - run: mix format --check-formatted
       - run: mix compile --force --warnings-as-errors
-      - run: mix test
+      - run: mix test --include long_running
       - run: mix espec
       - run: MIX_ENV=dev mix docs && ! mix docs 2>&1 | grep -q "warning:"

--- a/lib/membrane/clock.ex
+++ b/lib/membrane/clock.ex
@@ -121,7 +121,7 @@ defmodule Membrane.Clock do
         ratio: 1,
         subscribers: %{},
         time_provider:
-          options |> Keyword.get(:time_provider, fn -> System.monotonic_time(:millisecond) end)
+          options |> Keyword.get(:time_provider, fn -> System.monotonic_time(:nanosecond) end)
       }
       |> Map.merge(proxy_opts)
 
@@ -242,6 +242,6 @@ defmodule Membrane.Clock do
   defp send_ratio(pid, ratio), do: send(pid, {:membrane_clock_ratio, self(), ratio})
 
   defp get_time(time_provider) do
-    time_provider.() |> Time.milliseconds()
+    time_provider.() |> Time.nanoseconds()
   end
 end

--- a/lib/membrane/clock.ex
+++ b/lib/membrane/clock.ex
@@ -61,7 +61,7 @@ defmodule Membrane.Clock do
   Check the moduledoc for more details.
   """
   @type option_t ::
-          {:time_provider, (() -> milliseconds :: integer)}
+          {:time_provider, (() -> Time.t())}
           | {:proxy, boolean}
           | {:proxy_for, pid}
 
@@ -120,8 +120,7 @@ defmodule Membrane.Clock do
       %{
         ratio: 1,
         subscribers: %{},
-        time_provider:
-          options |> Keyword.get(:time_provider, fn -> System.monotonic_time(:nanosecond) end)
+        time_provider: options |> Keyword.get(:time_provider, fn -> Time.monotonic_time() end)
       }
       |> Map.merge(proxy_opts)
 
@@ -220,7 +219,7 @@ defmodule Membrane.Clock do
     till_next = till_next * Time.millisecond(1)
 
     case state.init_time do
-      nil -> %{state | init_time: get_time(state.time_provider), till_next: till_next}
+      nil -> %{state | init_time: state.time_provider.(), till_next: till_next}
       _ -> do_handle_clock_update(till_next, state)
     end
   end
@@ -229,7 +228,7 @@ defmodule Membrane.Clock do
     use Ratio
     %{till_next: from_previous, clock_time: clock_time} = state
     clock_time = clock_time + from_previous
-    ratio = clock_time / (get_time(state.time_provider) - state.init_time)
+    ratio = clock_time / (state.time_provider.() - state.init_time)
     state = %{state | clock_time: clock_time, till_next: till_next}
     broadcast_and_update_ratio(ratio, state)
   end
@@ -240,8 +239,4 @@ defmodule Membrane.Clock do
   end
 
   defp send_ratio(pid, ratio), do: send(pid, {:membrane_clock_ratio, self(), ratio})
-
-  defp get_time(time_provider) do
-    time_provider.() |> Time.nanoseconds()
-  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,8 @@ defmodule Membrane.Mixfile do
         "coveralls.html": :test
       ],
       test_coverage: [tool: ExCoveralls, test_task: "espec"],
-      deps: deps()
+      deps: deps(),
+      aliases: aliases()
     ]
   end
 
@@ -100,6 +101,12 @@ defmodule Membrane.Mixfile do
       {:dialyxir, "~> 1.0.0-rc.4", only: [:dev], runtime: false},
       {:bunch, github: "membraneframework/bunch"},
       {:ratio, "~> 2.0"}
+    ]
+  end
+
+  defp aliases do
+    [
+      test: "test --exclude long_running"
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -26,8 +26,7 @@ defmodule Membrane.Mixfile do
         "coveralls.html": :test
       ],
       test_coverage: [tool: ExCoveralls, test_task: "espec"],
-      deps: deps(),
-      aliases: aliases()
+      deps: deps()
     ]
   end
 
@@ -101,12 +100,6 @@ defmodule Membrane.Mixfile do
       {:dialyxir, "~> 1.0.0-rc.4", only: [:dev], runtime: false},
       {:bunch, github: "membraneframework/bunch"},
       {:ratio, "~> 2.0"}
-    ]
-  end
-
-  defp aliases do
-    [
-      test: "test --exclude long_running"
     ]
   end
 end

--- a/test/membrane/clock_test.exs
+++ b/test/membrane/clock_test.exs
@@ -6,7 +6,7 @@ defmodule Membrane.ClockTest do
   use ExUnit.Case
 
   test "should calculate proper ratio and send it to subscribers on each (but the first) update" do
-    clock = @module.start_link!(time_provider: fn -> receive do: (time: t -> t) end)
+    clock = @module.start_link!(time_provider: fn -> receive do: (time: t -> ms_to_ns(t)) end)
     @module.subscribe(clock)
     assert_receive {:membrane_clock_ratio, ^clock, @initial_ratio}
     send(clock, {:membrane_clock_update, 20})
@@ -23,7 +23,7 @@ defmodule Membrane.ClockTest do
 
   test "should handle different ratio formats" do
     use Ratio
-    clock = @module.start_link!(time_provider: fn -> receive do: (time: t -> t) end)
+    clock = @module.start_link!(time_provider: fn -> receive do: (time: t -> ms_to_ns(t)) end)
     send(clock, {:membrane_clock_update, 5})
     send(clock, time: 5)
     send(clock, {:membrane_clock_update, Ratio.new(1, 3)})
@@ -68,7 +68,7 @@ defmodule Membrane.ClockTest do
     end
 
     test "when more than one update has been sent" do
-      clock = @module.start_link!(time_provider: fn -> receive do: (time: t -> t) end)
+      clock = @module.start_link!(time_provider: fn -> receive do: (time: t -> ms_to_ns(t)) end)
       send(clock, {:membrane_clock_update, 20})
       send(clock, time: 3)
       send(clock, {:membrane_clock_update, random_time()})
@@ -156,4 +156,6 @@ defmodule Membrane.ClockTest do
   end
 
   defp random_time, do: :rand.uniform(10000)
+
+  defp ms_to_ns(e), do: e * 1_000_000
 end

--- a/test/membrane/integration/sync_test.exs
+++ b/test/membrane/integration/sync_test.exs
@@ -1,0 +1,45 @@
+defmodule Membrane.Integration.SyncTest do
+  use ExUnit.Case, async: false
+
+  alias Membrane.Support.Sync
+  alias Membrane.{Time, Testing}
+
+  @error 8
+  @timeout 500
+
+  @tag :long_running
+  test "When ration = 1 amount of lost ticks is roughly the same regardless of the time of transmission" do
+    tick_interval = 1
+
+    assert {:ok, pipeline} =
+             Testing.Pipeline.start_link(%Testing.Pipeline.Options{
+               elements: [
+                 source: %Sync.Source{
+                   tick_interval: tick_interval |> Time.milliseconds(),
+                   test_process: self()
+                 },
+                 sink: Sync.Sink
+               ]
+             })
+
+    for tries <- [100, 1000, 10000] do
+      Testing.Pipeline.play(pipeline)
+
+      Process.sleep(tick_interval * tries)
+
+      Testing.Pipeline.stop(pipeline)
+
+      ticks_amount = receive_ticks(pipeline)
+
+      assert_in_delta ticks_amount, tries, @error
+    end
+  end
+
+  defp receive_ticks(pipeline, amount \\ 0) do
+    receive do
+      :tick -> receive_ticks(pipeline, amount + 1)
+    after
+      @timeout -> amount
+    end
+  end
+end

--- a/test/membrane/integration/sync_test.exs
+++ b/test/membrane/integration/sync_test.exs
@@ -39,7 +39,7 @@ defmodule Membrane.Integration.SyncTest do
   test "Ratio modifies ticking pace correctly" do
     tick_interval = 100
     tries = 300
-    ratio_error = 0.05
+    ratio_error = 0.1
 
     actual_report_interval = 100
     reported_interval = 300

--- a/test/membrane/integration/sync_test.exs
+++ b/test/membrane/integration/sync_test.exs
@@ -8,7 +8,7 @@ defmodule Membrane.Integration.SyncTest do
   @timeout 500
 
   @tag :long_running
-  test "When ration = 1 amount of lost ticks is roughly the same regardless of the time of transmission" do
+  test "When ratio = 1 amount of lost ticks is roughly the same regardless of the time of transmission" do
     tick_interval = 1
 
     assert {:ok, pipeline} =
@@ -33,6 +33,46 @@ defmodule Membrane.Integration.SyncTest do
 
       assert_in_delta ticks_amount, tries, @error
     end
+  end
+
+  @tag :long_running
+  test "Ratio modifies ticking pace correctly" do
+    tick_interval = 100
+    tries = 300
+    ratio_error = 0.05
+
+    actual_report_interval = 100
+    reported_interval = 300
+
+    assert {:ok, pipeline} =
+             Testing.Pipeline.start_link(%Testing.Pipeline.Options{
+               elements: [
+                 source: %Sync.Source{
+                   tick_interval: tick_interval |> Time.milliseconds(),
+                   test_process: self()
+                 },
+                 sink: Sync.Sink
+               ]
+             })
+
+    %{clock_provider: %{clock: original_clock, provider: :sink}} = :sys.get_state(pipeline)
+
+    Testing.Pipeline.play(pipeline)
+
+    for _ <- 1..tries do
+      send(original_clock, {:membrane_clock_update, reported_interval})
+      Process.sleep(actual_report_interval)
+    end
+
+    Testing.Pipeline.stop(pipeline)
+
+    ticks_amount = receive_ticks(pipeline)
+
+    actual_test_time = tries * actual_report_interval
+    expected_ratio = 3.0
+    actual_tick_time = actual_test_time / ticks_amount
+
+    assert_in_delta actual_tick_time / tick_interval, expected_ratio, ratio_error
   end
 
   defp receive_ticks(pipeline, amount \\ 0) do

--- a/test/support/sync/sink.ex
+++ b/test/support/sync/sink.ex
@@ -4,7 +4,4 @@ defmodule Membrane.Support.Sync.Sink do
   def_input_pad :input, caps: :any, demand_unit: :buffers
 
   def_clock()
-
-  @impl true
-  def handle_init(_opts), do: {:ok, :ignored}
 end

--- a/test/support/sync/sink.ex
+++ b/test/support/sync/sink.ex
@@ -1,0 +1,10 @@
+defmodule Membrane.Support.Sync.Sink do
+  use Membrane.Sink
+
+  def_input_pad :input, caps: :any, demand_unit: :buffers
+
+  def_clock()
+
+  @impl true
+  def handle_init(_opts), do: {:ok, :ignored}
+end

--- a/test/support/sync/source.ex
+++ b/test/support/sync/source.ex
@@ -7,9 +7,6 @@ defmodule Membrane.Support.Sync.Source do
               test_process: [type: :pid]
 
   @impl true
-  def handle_init(opts), do: {:ok, opts}
-
-  @impl true
   def handle_prepared_to_playing(ctx, %{tick_interval: interval} = state) do
     clock = ctx.pipeline_clock
     {{:ok, start_timer: {:my_timer, interval, clock}}, state}
@@ -26,7 +23,4 @@ defmodule Membrane.Support.Sync.Source do
 
   @impl true
   def handle_demand(:output, _size, _, _ctx, state), do: {:ok, state}
-
-  @impl true
-  def handle_event(_pad, event, _ctx, state), do: {{:ok, forward: event}, state}
 end

--- a/test/support/sync/source.ex
+++ b/test/support/sync/source.ex
@@ -1,0 +1,32 @@
+defmodule Membrane.Support.Sync.Source do
+  use Membrane.Source
+
+  def_output_pad :output, caps: :any
+
+  def_options tick_interval: [type: :time],
+              test_process: [type: :pid]
+
+  @impl true
+  def handle_init(opts), do: {:ok, opts}
+
+  @impl true
+  def handle_prepared_to_playing(ctx, %{tick_interval: interval} = state) do
+    clock = ctx.pipeline_clock
+    {{:ok, start_timer: {:my_timer, interval, clock}}, state}
+  end
+
+  @impl true
+  def handle_playing_to_prepared(_ctx, state), do: {{:ok, stop_timer: :my_timer}, state}
+
+  @impl true
+  def handle_tick(:my_timer, _ctx, state) do
+    send(state.test_process, :tick)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_demand(:output, _size, _, _ctx, state), do: {:ok, state}
+
+  @impl true
+  def handle_event(_pad, event, _ctx, state), do: {{:ok, forward: event}, state}
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(exclude: [:long_running])


### PR DESCRIPTION
This PR adds integration tests for Clock and Timer module. It introduces some longer tests that will be run only on CircleCI by default.