### PR TITLE
Added fail path for Testing Pipeline start

### DIFF
--- a/lib/membrane/testing/pipeline.ex
+++ b/lib/membrane/testing/pipeline.ex
@@ -170,18 +170,25 @@ defmodule Membrane.Testing.Pipeline do
     do_start(:start, pipeline_options, process_options)
   end
 
-  defp do_start(_type, %Options{elements: nil, module: nil}, _process_options),
-    do: {:error, :no_config}
+  defp do_start(_type, %Options{elements: nil, module: nil}, _process_options) do
+    raise """
+
+    You provided no information about pipeline contents. Please provide either:
+     - list of elemenst via `elements` field of Options struct with optional links between
+     them via `links` field of `Options` struct
+     - module that implements `Membrane.Pipeline` callbacks via `module` field of `Options`
+     struct
+    """
+  end
 
   defp do_start(_type, %Options{elements: elements, module: module}, _process_options)
        when is_atom(module) and module != nil and elements != nil do
-    warn("""
+    raise """
+
     When working with Membrane.Testing.Pipeline you can't provide both
     override module and elements list in the Membrane.Testing.Pipeline.Options
     struct.
-    """)
-
-    {:error, :wrong_options}
+    """
   end
 
   defp do_start(type, options, process_options) do

--- a/test/membrane/testing/pipeline_test.exs
+++ b/test/membrane/testing/pipeline_test.exs
@@ -51,14 +51,14 @@ defmodule Membrane.Testing.PipelineTest do
   end
 
   describe "When starting Testing Pipeline does" do
-    test "returns an error if a pipeline is started with both elements and module provided in options" do
-      assert_raise RuntimeError, fn ->
+    test "raises an error if a pipeline is started with both elements and module provided in options" do
+      assert_raise RuntimeError, ~r/override module and elements list/, fn ->
         Pipeline.start(%Pipeline.Options{elements: [elem: Elem], module: Mod})
       end
     end
 
-    test "returns an error if no means of generating spec are provided (no elements, no module)" do
-      assert_raise RuntimeError, fn ->
+    test "raises an error if no means of generating spec are provided (no elements, no module)" do
+      assert_raise RuntimeError, ~r/You provided no information about pipeline contents./, fn ->
         Pipeline.start(%Pipeline.Options{elements: nil, module: nil})
       end
     end

--- a/test/membrane/testing/pipeline_test.exs
+++ b/test/membrane/testing/pipeline_test.exs
@@ -1,0 +1,63 @@
+defmodule Membrane.Testing.PipelineTest do
+  use ExUnit.Case
+
+  alias Membrane.Testing.Pipeline
+
+  defmodule MockPipeline do
+    use Membrane.Pipeline
+
+    @impl true
+    def handle_init(_opts), do: {{:ok, %Membrane.Pipeline.Spec{}}, :state}
+  end
+
+  describe "When initializing Testing Pipeline" do
+    test "generates links if only elements were provided" do
+      elements = [elem: Elem, elem2: Elem]
+      links = %{{:elem, :output} => {:elem2, :input}}
+      options = %Pipeline.Options{elements: elements}
+      assert {{:ok, spec}, state} = Pipeline.handle_init(options)
+      assert state == %Pipeline.State{module: nil, test_process: nil}
+
+      assert spec == %Membrane.Pipeline.Spec{
+               links: links,
+               children: elements
+             }
+    end
+
+    test "uses prepared links if they were provided" do
+      elements = [elem: Elem, elem2: Elem]
+      links = %{{:elem, :output} => {:elem2, :input}}
+      options = %Pipeline.Options{elements: elements, links: links}
+      assert {{:ok, spec}, state} = Pipeline.handle_init(options)
+      assert state == %Pipeline.State{module: nil, test_process: nil}
+
+      assert spec == %Membrane.Pipeline.Spec{
+               links: links,
+               children: elements
+             }
+    end
+
+    test "if no elements nor links were provided uses module's callback" do
+      options = %Pipeline.Options{module: MockPipeline}
+      assert {{:ok, spec}, state} = Pipeline.handle_init(options)
+      assert spec == %Membrane.Pipeline.Spec{}
+
+      assert state == %Pipeline.State{
+               custom_pipeline_state: :state,
+               module: MockPipeline,
+               test_process: nil
+             }
+    end
+  end
+
+  describe "When starting Testing Pipeline does" do
+    test "returns an error if a pipeline is started with both elements and module provided in options" do
+      assert {:error, :wrong_options} =
+               Pipeline.start(%Pipeline.Options{elements: [elem: Elem], module: Mod})
+    end
+
+    test "returns an error if no means of generating spec are provided (no elements, no module)" do
+      assert {:error, :no_config} = Pipeline.start(%Pipeline.Options{elements: nil, module: nil})
+    end
+  end
+end

--- a/test/membrane/testing/pipeline_test.exs
+++ b/test/membrane/testing/pipeline_test.exs
@@ -52,12 +52,15 @@ defmodule Membrane.Testing.PipelineTest do
 
   describe "When starting Testing Pipeline does" do
     test "returns an error if a pipeline is started with both elements and module provided in options" do
-      assert {:error, :wrong_options} =
-               Pipeline.start(%Pipeline.Options{elements: [elem: Elem], module: Mod})
+      assert_raise RuntimeError, fn ->
+        Pipeline.start(%Pipeline.Options{elements: [elem: Elem], module: Mod})
+      end
     end
 
     test "returns an error if no means of generating spec are provided (no elements, no module)" do
-      assert {:error, :no_config} = Pipeline.start(%Pipeline.Options{elements: nil, module: nil})
+      assert_raise RuntimeError, fn ->
+        Pipeline.start(%Pipeline.Options{elements: nil, module: nil})
+      end
     end
   end
 end


### PR DESCRIPTION
Before there was possibility to pass invalid options to `Membrane.Testing.Pipeline.start/_link/2`. For example:
 - no elements nor module
 - both module and elements provided