### PR TITLE
Don't use deprecated bare spec returned from init

### DIFF
--- a/test/membrane/pipeline_test.exs
+++ b/test/membrane/pipeline_test.exs
@@ -25,7 +25,7 @@ defmodule Membrane.PipelineTest do
       end
     end
 
-    test "executes successfully when callback module's handle init returns {{:ok, spec}},state} " do
+    test "executes successfully when callback module's handle_init returns {{:ok, spec: spec}}, state} " do
       defmodule InvalidPipeline do
         use Membrane.Pipeline
 

--- a/test/membrane/pipeline_test.exs
+++ b/test/membrane/pipeline_test.exs
@@ -32,7 +32,7 @@ defmodule Membrane.PipelineTest do
         @impl true
         def handle_init(_) do
           spec = %Membrane.Pipeline.Spec{}
-          {{:ok, spec}, %{}}
+          {{:ok, spec: spec}, %{}}
         end
       end
 

--- a/test/membrane/testing/pipeline_test.exs
+++ b/test/membrane/testing/pipeline_test.exs
@@ -7,7 +7,7 @@ defmodule Membrane.Testing.PipelineTest do
     use Membrane.Pipeline
 
     @impl true
-    def handle_init(_opts), do: {{:ok, %Membrane.Pipeline.Spec{}}, :state}
+    def handle_init(_opts), do: {{:ok, spec: %Membrane.Pipeline.Spec{}}, :state}
   end
 
   describe "When initializing Testing Pipeline" do
@@ -15,7 +15,7 @@ defmodule Membrane.Testing.PipelineTest do
       elements = [elem: Elem, elem2: Elem]
       links = %{{:elem, :output} => {:elem2, :input}}
       options = %Pipeline.Options{elements: elements}
-      assert {{:ok, spec}, state} = Pipeline.handle_init(options)
+      assert {{:ok, spec: spec}, state} = Pipeline.handle_init(options)
       assert state == %Pipeline.State{module: nil, test_process: nil}
 
       assert spec == %Membrane.Pipeline.Spec{
@@ -28,7 +28,7 @@ defmodule Membrane.Testing.PipelineTest do
       elements = [elem: Elem, elem2: Elem]
       links = %{{:elem, :output} => {:elem2, :input}}
       options = %Pipeline.Options{elements: elements, links: links}
-      assert {{:ok, spec}, state} = Pipeline.handle_init(options)
+      assert {{:ok, spec: spec}, state} = Pipeline.handle_init(options)
       assert state == %Pipeline.State{module: nil, test_process: nil}
 
       assert spec == %Membrane.Pipeline.Spec{
@@ -39,7 +39,7 @@ defmodule Membrane.Testing.PipelineTest do
 
     test "if no elements nor links were provided uses module's callback" do
       options = %Pipeline.Options{module: MockPipeline}
-      assert {{:ok, spec}, state} = Pipeline.handle_init(options)
+      assert {{:ok, spec: spec}, state} = Pipeline.handle_init(options)
       assert spec == %Membrane.Pipeline.Spec{}
 
       assert state == %Pipeline.State{


### PR DESCRIPTION
#192 was not based on current master and missed that returning `{:ok, spec}, state}` from pipeline's handle_init was deprecated (should be `{:ok, spec: spec}, state}`) and automatically wrapped