### PR TITLE
Fix EOS and unlinking in bins problems

### DIFF
--- a/lib/membrane/bin.ex
+++ b/lib/membrane/bin.ex
@@ -247,6 +247,12 @@ defmodule Membrane.Bin do
   end
 
   @impl GenServer
+  def handle_info(Message.new(:handle_unlink, pad_ref), state) do
+    PadController.handle_pad_removed(pad_ref, state)
+    |> noreply()
+  end
+
+  @impl GenServer
   def handle_info(message, state) do
     Parent.MessageDispatcher.handle_message(message, state)
   end

--- a/lib/membrane/core/child/pad_controller.ex
+++ b/lib/membrane/core/child/pad_controller.ex
@@ -302,7 +302,7 @@ defmodule Membrane.Core.Child.PadController do
     do: state |> Bunch.Access.put_in([:pads, :dynamic_currently_linking], [])
 
   @spec generate_eos_if_needed(Pad.ref_t(), state_t()) :: Type.stateful_try_t(state_t)
-  defp generate_eos_if_needed(pad_ref, state) do
+  def generate_eos_if_needed(pad_ref, state) do
     direction = PadModel.get_data!(state, pad_ref, :direction)
     eos? = PadModel.get_data!(state, pad_ref, :end_of_stream?)
 

--- a/lib/membrane/core/child/pad_controller.ex
+++ b/lib/membrane/core/child/pad_controller.ex
@@ -334,7 +334,7 @@ defmodule Membrane.Core.Child.PadController do
   end
 
   @spec handle_pad_removed(Pad.ref_t(), state_t()) :: Type.stateful_try_t(state_t)
-  defp handle_pad_removed(ref, state) do
+  def handle_pad_removed(ref, state) do
     %{direction: direction, availability: availability} = PadModel.get_data!(state, ref)
     name = Pad.name_by_ref(ref)
 

--- a/lib/membrane/core/element/event_controller.ex
+++ b/lib/membrane/core/element/event_controller.ex
@@ -122,8 +122,11 @@ defmodule Membrane.Core.Element.EventController do
   end
 
   defp handle_special_event(pad_ref, %Event.EndOfStream{}, state) do
-    with %{direction: :input, start_of_stream?: true, end_of_stream?: false} <-
-           PadModel.get_data!(state, pad_ref) do
+    pad_data = PadModel.get_data!(state, pad_ref)
+
+    with %{direction: :input, start_of_stream?: true, end_of_stream?: false} <- pad_data,
+         %{playback: playback} <- state,
+         %{state: :playing} <- playback do
       state
       |> PadModel.set_data!(pad_ref, :end_of_stream?, true)
       ~> {{:ok, :handle}, &1}
@@ -132,7 +135,11 @@ defmodule Membrane.Core.Element.EventController do
         {{:error, {:received_end_of_stream_through_output, pad_ref}}, state}
 
       %{end_of_stream?: true} ->
-        {{:error, {:end_of_stream_already_received, pad_ref}}, state}
+        warn("Ignoring event EndOfStream as it has already come before", state)
+        {{:ok, :ignore}, state}
+
+      %{state: playback_state} ->
+        {{:error, {:received_eos_in_incorrect_state, pad_ref, playback_state}}, state}
 
       %{start_of_stream?: false} ->
         {{:ok, :ignore}, state}

--- a/lib/membrane/core/element/event_controller.ex
+++ b/lib/membrane/core/element/event_controller.ex
@@ -138,7 +138,9 @@ defmodule Membrane.Core.Element.EventController do
         {{:ok, :ignore}, state}
 
       %{state: playback_state} ->
-        raise {:received_eos_in_incorrect_state, pad_ref, playback_state}
+        raise "Received end of stream event in an incorrect state. State: #{
+                inspect(playback_state)
+              }, on pad: #{inspect(pad_ref)}"
 
       %{start_of_stream?: false} ->
         {{:ok, :ignore}, state}

--- a/lib/membrane/core/element/event_controller.ex
+++ b/lib/membrane/core/element/event_controller.ex
@@ -125,8 +125,7 @@ defmodule Membrane.Core.Element.EventController do
     pad_data = PadModel.get_data!(state, pad_ref)
 
     with %{direction: :input, start_of_stream?: true, end_of_stream?: false} <- pad_data,
-         %{playback: playback} <- state,
-         %{state: :playing} <- playback do
+         %{state: :playing} <- state.playback do
       state
       |> PadModel.set_data!(pad_ref, :end_of_stream?, true)
       ~> {{:ok, :handle}, &1}
@@ -135,11 +134,11 @@ defmodule Membrane.Core.Element.EventController do
         {{:error, {:received_end_of_stream_through_output, pad_ref}}, state}
 
       %{end_of_stream?: true} ->
-        warn("Ignoring event EndOfStream as it has already come before", state)
+        debug("Ignoring event EndOfStream as it has already come before", state)
         {{:ok, :ignore}, state}
 
       %{state: playback_state} ->
-        {{:error, {:received_eos_in_incorrect_state, pad_ref, playback_state}}, state}
+        raise {:received_eos_in_incorrect_state, pad_ref, playback_state}
 
       %{start_of_stream?: false} ->
         {{:ok, :ignore}, state}

--- a/test/membrane/core/child/pad_controller_test.exs
+++ b/test/membrane/core/child/pad_controller_test.exs
@@ -70,7 +70,9 @@ defmodule Membrane.Core.Child.PadControllerTest do
       }
       |> Map.merge(info)
 
-    state |> Bunch.Access.put_in([:pads, :data, pad_name], data)
+    state
+    |> Bunch.Access.put_in([:pads, :data, pad_name], data)
+    |> Bunch.Struct.put_in([:playback, :state], :playing)
   end
 
   defp prepare_dynamic_state(elem_module, name, playback_state, pad_name, pad_ref) do

--- a/test/membrane/core/element/event_controller_test.exs
+++ b/test/membrane/core/element/event_controller_test.exs
@@ -8,7 +8,6 @@ defmodule Membrane.Core.Element.EventControllerTest do
   alias Membrane.Event
   alias Membrane.Pad.Data
   alias Membrane.Core.InputBuffer
-  alias Membrane.Core.Element.LifecycleController
 
   defmodule MockEventHandlingElement do
     use Membrane.Filter
@@ -76,15 +75,6 @@ defmodule Membrane.Core.Element.EventControllerTest do
       state = put_start_of_stream(state, :input)
 
       assert {:ok, state} = EventController.handle_event(:input, %Event.EndOfStream{}, state)
-      assert state.pads.data.input.end_of_stream?
-    end
-
-    test "end of stream is generated when playback state changes from :playing to :prepared", %{
-      state: state
-    } do
-      state = put_start_of_stream(state, :input)
-
-      {:ok, state} = LifecycleController.handle_playback_state(:playing, :prepared, state)
       assert state.pads.data.input.end_of_stream?
     end
   end

--- a/test/membrane/core/element/event_controller_test.exs
+++ b/test/membrane/core/element/event_controller_test.exs
@@ -8,6 +8,7 @@ defmodule Membrane.Core.Element.EventControllerTest do
   alias Membrane.Event
   alias Membrane.Pad.Data
   alias Membrane.Core.InputBuffer
+  alias Membrane.Core.Element.LifecycleController
 
   defmodule MockEventHandlingElement do
     use Membrane.Filter
@@ -35,6 +36,7 @@ defmodule Membrane.Core.Element.EventControllerTest do
           pads: %{
             data: %{
               input: %Data{
+                ref: :input,
                 accepted_caps: :any,
                 direction: :input,
                 pid: self(),
@@ -71,14 +73,18 @@ defmodule Membrane.Core.Element.EventControllerTest do
     end
 
     test "end of stream successfully", %{state: state} do
-      pads =
-        Bunch.Access.update_in(state.pads, [:data, :input], fn data ->
-          %{data | start_of_stream?: true}
-        end)
-
-      state = %{state | pads: pads}
+      state = put_start_of_stream(state, :input)
 
       assert {:ok, state} = EventController.handle_event(:input, %Event.EndOfStream{}, state)
+      assert state.pads.data.input.end_of_stream?
+    end
+
+    test "end of stream is generated when playback state changes from :playing to :prepared", %{
+      state: state
+    } do
+      state = put_start_of_stream(state, :input)
+
+      {:ok, state} = LifecycleController.handle_playback_state(:playing, :prepared, state)
       assert state.pads.data.input.end_of_stream?
     end
   end
@@ -92,5 +98,14 @@ defmodule Membrane.Core.Element.EventControllerTest do
       assert {{:error, {:handle_event, :cause}}, ^state} =
                EventController.handle_event(:input, %Event.Discontinuity{}, state)
     end
+  end
+
+  defp put_start_of_stream(state, pad_ref) do
+    pads =
+      Bunch.Access.update_in(state.pads, [:data, pad_ref], fn data ->
+        %{data | start_of_stream?: true}
+      end)
+
+    %{state | pads: pads}
   end
 end

--- a/test/membrane/core/element/lifecycle_controller_test.exs
+++ b/test/membrane/core/element/lifecycle_controller_test.exs
@@ -1,0 +1,53 @@
+defmodule Membrane.Core.Element.LifecycleControllerTest do
+  use ExUnit.Case
+
+  require Membrane.Core.Message
+
+  alias Membrane.Core.Element.State
+  alias Membrane.Core.Message
+  alias Membrane.Pad.Data
+  alias Membrane.Core.InputBuffer
+  alias Membrane.Core.Element.LifecycleController
+
+  defmodule DummyElement do
+    use Membrane.Filter
+    def_output_pad :output, caps: :any
+  end
+
+  setup do
+    input_buf = InputBuffer.init(:test, :buffers, self(), :some_pad, preferred_size: 10)
+
+    state =
+      %{
+        State.new(%{module: DummyElement, name: :test_name, clock: nil, sync: nil})
+        | watcher: self(),
+          type: :filter,
+          pads: %{
+            data: %{
+              input: %Data{
+                ref: :input,
+                accepted_caps: :any,
+                direction: :input,
+                pid: self(),
+                mode: :pull,
+                start_of_stream?: true,
+                end_of_stream?: false,
+                input_buf: input_buf,
+                demand: 0
+              }
+            }
+          }
+      }
+      |> Bunch.Struct.put_in([:playback, :state], :playing)
+
+    assert_received Message.new(:demand, 10, for_pad: :some_pad)
+    [state: state]
+  end
+
+  test "End of stream is generated when playback state changes from :playing to :prepared", %{
+    state: state
+  } do
+    {:ok, state} = LifecycleController.handle_playback_state(:playing, :prepared, state)
+    assert state.pads.data.input.end_of_stream?
+  end
+end


### PR DESCRIPTION
This PR fixes:
* Wrong elements' behaviour on duplicated `EndOfStream` events
* Not notifying parents about `EndOfStream` event
* Not generating `EndOfStream` when elements went from `:playing` to `:prepared`