### PR TITLE
Add output from buffers to Testing.Source

### DIFF
--- a/lib/membrane/testing/source.ex
+++ b/lib/membrane/testing/source.ex
@@ -83,6 +83,22 @@ defmodule Membrane.Testing.Source do
     {action, generator_state + size}
   end
 
+  @doc """
+  Creates output with generator function from list of buffers
+  """
+  @spec output_from_buffers([Buffer.t()]) :: {[Buffer.t()], generator()}
+  def output_from_buffers(data) do
+    fun = fn state, size ->
+      {buffers, leftover} = Enum.split(state, size)
+      buffer_action = [{:buffer, {:output, buffers}}]
+      event_action = if leftover == [], do: [end_of_stream: :output], else: []
+      to_send = buffer_action ++ event_action
+      {to_send, leftover}
+    end
+
+    {data, fun}
+  end
+
   defp get_actions(%{generator_state: generator_state, output: actions_generator} = state, size)
        when is_function(actions_generator) do
     {actions, generator_state} = actions_generator.(generator_state, size)

--- a/test/membrane/testing/source_test.exs
+++ b/test/membrane/testing/source_test.exs
@@ -43,4 +43,22 @@ defmodule Membrane.Testing.SourceTest do
       assert %Buffer{payload: payload} == buffer
     end
   end
+
+  test "Created generator function sends end_of_stream if leftover is empty" do
+    buffers = [%Membrane.Buffer{payload: 1}]
+    assert {state, generator} = Source.output_from_buffers(buffers)
+
+    assert {{:ok, actions}, state} =
+             Source.handle_demand(:output, 2, :buffers, nil, %{
+               generator_state: state,
+               output: generator
+             })
+
+    assert [
+             {:buffer, {:output, [buffer]}},
+             {:end_of_stream, :output}
+           ] = actions
+
+    assert %Buffer{payload: 1} == buffer
+  end
 end


### PR DESCRIPTION
A simple function for creating source from list of buffers, not payloads.