### PR TITLE
lib/membrane/core/bin/pad_controller.ex: refactored Enum to Stream

### DIFF
--- a/lib/membrane/core/bin/pad_controller.ex
+++ b/lib/membrane/core/bin/pad_controller.ex
@@ -186,7 +186,7 @@ defmodule Membrane.Core.Bin.PadController do
         end
       end,
       fn state -> {[state], state} end,
-      fn _ -> :ok end
+      fn _acc -> :ok end
     )
     |> Enum.to_list()
     |> List.first()


### PR DESCRIPTION
No one asked me to but I refactored Membrane.Core.Bin.PadController. respond_links/2  to use Stream. 
I enjoyed it as an exercise so feel free to just close this if you don't want it. :)