### PR TITLE
Remove SKILL.md from the HexDocs sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ You can also [follow Membrane on X (Twitter)](https://twitter.com/ElixirMembrane
 
 If you already had a chance to use Membrane, we will be greateful if could fill out quick [survey](https://forms.gle/dgVDFHUD7CUGxU5VA) to help us improve framework and decide on what to do next.
 
+For people who write Membrane code with AI assistants, we ship a [dedicated skill](#membrane-skill-for-ai-assistants) for them.
+
 Membrane is maintained by [Software Mansion](https://swmansion.com).
 
 ## Quick start

--- a/mix.exs
+++ b/mix.exs
@@ -131,8 +131,7 @@ defmodule Membrane.Mixfile do
 
   defp extras do
     [
-      {"skills/membrane-framework/SKILL.md",
-       [title: "Membrane Framework AI Skill"]},
+      {"skills/membrane-framework/SKILL.md", [title: "Membrane Framework AI Skill"]},
       "README.md",
       {"guides/llms/packages_list.md",
        [title: "Packages in the Membrane ecosystem", hidden: true]},

--- a/mix.exs
+++ b/mix.exs
@@ -107,9 +107,22 @@ defmodule Membrane.Mixfile do
         Membrane.RCMessage
       ],
       groups_for_modules: groups_for_modules(),
-      groups_for_extras: groups_for_extras()
+      groups_for_extras: groups_for_extras(),
+      before_closing_head_tag: &before_closing_head_tag/1
     ]
   end
+
+  # Hides the AI skill page from the sidebar while keeping it published and linked from llms.txt.
+  defp before_closing_head_tag(:html) do
+    """
+    <style>
+      #sidebar li:has(> a[href$="skill.html"]),
+      #sidebar a[href$="skill.html"] { display: none; }
+    </style>
+    """
+  end
+
+  defp before_closing_head_tag(_format), do: ""
 
   defp packages_in_ecosystem do
     {packages, _bindings} = Code.eval_file(@hex_packages_path)
@@ -119,7 +132,7 @@ defmodule Membrane.Mixfile do
   defp extras do
     [
       {"skills/membrane-framework/SKILL.md",
-       [title: "Membrane Framework AI Skill", hidden: true]},
+       [title: "Membrane Framework AI Skill"]},
       "README.md",
       {"guides/llms/packages_list.md",
        [title: "Packages in the Membrane ecosystem", hidden: true]},

--- a/skills/membrane-framework/SKILL.md
+++ b/skills/membrane-framework/SKILL.md
@@ -7,7 +7,7 @@ alwaysApply: false
 
 # Membrane Framework
 
-**Package**: `membrane_core` ~> 1.2 | **Docs**: https://hexdocs.pm/membrane_core/ | **Module index**: https://hexdocs.pm/membrane_core/llms.txt | **Demos**: https://github.com/membraneframework/membrane_demo | **All packages**: [packages_list.md](../../guides/llms/packages_list.md)
+**Package**: `membrane_core` ~> 1.3 | **Docs**: https://hexdocs.pm/membrane_core/ | **Module index**: https://hexdocs.pm/membrane_core/llms.txt | **Demos**: https://github.com/membraneframework/membrane_demo | **All packages**: [packages_list.md](../../guides/llms/packages_list.md)
 
 ## How to Approach Tasks
 


### PR DESCRIPTION
Unfortunately, `hidden: true` was just a hallucination 💭. This time I have checked manually, if it works 😉 