### PR TITLE
Adjust to flat structure of membrane_demo

### DIFF
--- a/lib/mix/tasks/membrane.demo.ex
+++ b/lib/mix/tasks/membrane.demo.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.Membrane.Demo do
   @moduledoc """
   Download Membrane demos and examples. Requires `git` installed.
 
-    $ mix membrane.demo [-a] [-l] [-d <repo_dir>] [<demos> ...]
+    $ mix membrane.demo [-a] [-l] [-d <repo_path>] [<demos> ...]
 
   ## Options
   * `-l, --list` - List all demos available and their brief descriptions.
@@ -93,13 +93,13 @@ defmodule Mix.Tasks.Membrane.Demo do
   end
 
   defp copy_all_demos(target_dir) do
-    repo_dir = Path.join(target_dir, "membrane_demo")
-    execute_git_command(["clone", "-q", "--depth", "1", @demos_clone_url, repo_dir])
+    repo_path = Path.join(target_dir, "membrane_demo")
+    execute_git_command(["clone", "-q", "--depth", "1", @demos_clone_url, repo_path])
   end
 
   defp copy_specific_demos(target_dir, demos_names) do
-    repo_dir = Path.join(target_dir, "membrane_demo")
-    execute_git_command(["clone", "-q", "--depth", "1", "-n", @demos_clone_url, repo_dir])
+    repo_path = Path.join(target_dir, "membrane_demo")
+    execute_git_command(["clone", "-q", "--depth", "1", "-n", @demos_clone_url, repo_path])
 
     Enum.each(demos_names, fn demo_name ->
       case copy_demo(target_dir, demo_name) do
@@ -113,15 +113,15 @@ defmodule Mix.Tasks.Membrane.Demo do
       end
     end)
 
-    File.rm_rf!(repo_dir)
+    File.rm_rf!(repo_path)
   end
 
   defp copy_demo(target_dir, demo_name) do
-    repo_dir = Path.join(target_dir, "membrane_demo")
-    demo_path = Path.join(repo_dir, demo_name)
+    repo_path = Path.join(target_dir, "membrane_demo")
+    demo_path = Path.join(repo_path, demo_name)
 
-    execute_git_command(["sparse-checkout", "set", demo_name], repo_dir)
-    execute_git_command(["checkout"], repo_dir)
+    execute_git_command(["sparse-checkout", "set", demo_name], repo_path)
+    execute_git_command(["checkout"], repo_path)
 
     case File.cp_r(demo_path, Path.join(target_dir, demo_name)) do
       {:ok, _files} -> :ok

--- a/lib/mix/tasks/membrane.demo.ex
+++ b/lib/mix/tasks/membrane.demo.ex
@@ -24,8 +24,6 @@ defmodule Mix.Tasks.Membrane.Demo do
     d: :directory
   ]
 
-  @demos_search_list [".", "livebooks"]
-
   @demos_readme_url "https://raw.githubusercontent.com/membraneframework/membrane_demo/refs/heads/master/README.md"
   @demos_clone_url "https://github.com/membraneframework/membrane_demo.git"
 
@@ -120,20 +118,15 @@ defmodule Mix.Tasks.Membrane.Demo do
 
   defp copy_demo(target_dir, demo_name) do
     repo_dir = Path.join(target_dir, "membrane_demo")
+    demo_path = Path.join(repo_dir, demo_name)
 
-    Enum.reduce_while(@demos_search_list, :error, fn demo_dir, _status ->
-      demo_path = Path.join([repo_dir, demo_dir, demo_name])
+    execute_git_command(["sparse-checkout", "set", demo_name], repo_dir)
+    execute_git_command(["checkout"], repo_dir)
 
-      demo_name_path = if demo_dir == ".", do: demo_name, else: Path.join(demo_dir, demo_name)
-
-      execute_git_command(["sparse-checkout", "set", demo_name_path], repo_dir)
-      execute_git_command(["checkout"], repo_dir)
-
-      case File.cp_r(demo_path, Path.join(target_dir, Path.basename(demo_path))) do
-        {:ok, _files} -> {:halt, :ok}
-        {:error, :enoent, _dir} -> {:cont, :error}
-      end
-    end)
+    case File.cp_r(demo_path, Path.join(target_dir, demo_name)) do
+      {:ok, _files} -> :ok
+      {:error, :enoent, _dir} -> :error
+    end
   end
 
   defp execute_git_command(argv, dir \\ ".") do


### PR DESCRIPTION
membrane_demo no longer has `livebooks` directory, so we can just assume every demo is at the root of the repo.